### PR TITLE
feat: add meticulous-brightness service to root filesystem

### DIFF
--- a/make-rootfs.sh
+++ b/make-rootfs.sh
@@ -52,6 +52,11 @@ function a_unpack_base() {
     ln -s /lib/systemd/system/meticulous-rauc.service \
         ${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/meticulous-rauc.service
 
+    install -m 0644 ${SERVICES_DIR}/meticulous-brightness.service \
+        ${ROOTFS_DIR}/lib/systemd/system
+    ln -s /lib/systemd/system/meticulous-brightness.service \
+        ${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/meticulous-brightness.service
+
     echo "SystemMaxUse=1G" >>${ROOTFS_DIR}/etc/systemd/journald.conf
 }
 

--- a/system-services/meticulous-brightness.service
+++ b/system-services/meticulous-brightness.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set Full Brightness at Startup
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'echo 4095 > /sys/class/backlight/backlight/brightness'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit updates the make-rootfs.sh script to install the meticulous-brightness.service and create the appropriate symbolic link in the systemd directory. Additionally, it includes the meticulous-brightness.service file to be tracked in the repository.