### PR TITLE
feat: update USB current configuration to 330 µA

### DIFF
--- a/make-rootfs.sh
+++ b/make-rootfs.sh
@@ -57,6 +57,11 @@ function a_unpack_base() {
     ln -s /lib/systemd/system/meticulous-brightness.service \
         ${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/meticulous-brightness.service
 
+    install -m 0644 ${SERVICES_DIR}/meticulous-usb-current.service \
+        ${ROOTFS_DIR}/lib/systemd/system
+    ln -s /lib/systemd/system/meticulous-usb-current.service \
+        ${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/meticulous-usb-current.service
+
     echo "SystemMaxUse=1G" >>${ROOTFS_DIR}/etc/systemd/journald.conf
 }
 

--- a/system-services/meticulous-usb-current.service
+++ b/system-services/meticulous-usb-current.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set USB Current at Startup
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/i2cset -f -y 1 0x3d 0x02 0x12
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The USB module was previously configured to deliver 80 µA of current, which is insufficient for charging devices requiring higher current. This commit updates the configuration to deliver 330 µA of current by modifying the control register settings.

Additionally, the  script is updated to install and enable the , ensuring the new current configuration
is applied correctly.