### PR TITLE
Add USB connection handler and recovery update support 

### DIFF
--- a/etc/udev/rules.d/media_updater.rules
+++ b/etc/udev/rules.d/media_updater.rules
@@ -1,0 +1,8 @@
+#This rule applies only for usb storage devices partitions
+
+#According to udevadm info /dev/someUsbStorage -a
+ACTION=="add" \
+, KERNEL=="sd?[1-9]"\
+, SUBSYSTEM=="block"\
+, DRIVERS=="usb-storage"\
+, RUN="/etc/usb_updater/media_handler.sh %k %n"

--- a/etc/usb_updater/media_handler.sh
+++ b/etc/usb_updater/media_handler.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+MOUNT_POINT="/tmp/possible_updater"
+DEVICE_KERNEL_NAME="$1"
+PARTITION_NUMBER=$2
+
+USB_PATH="/dev/$DEVICE_KERNEL_NAME"
+
+USB_AS_UPDATER=true
+rauc_files=""
+
+#if the mount point exists, it is being updated, discard this usb as updater device
+if [ -d $MOUNT_POINT ]; then
+    USB_AS_UPDATER=false
+else
+
+    echo "partition number received: $PARTITION_NUMBER"
+
+    if [ "$PARTITION_NUMBER" == "1" ]; then
+        mkdir $MOUNT_POINT
+        echo "attempting to mount: $USB_PATH"
+        mount $USB_PATH $MOUNT_POINT 1>&2
+        error_mounting="$?"
+        if [ $error_mounting == "0" ]; then
+            echo "device mounted"
+        else
+            echo "device $USB_PATH could not be mounted: $error_mounting"
+            rm -r $MOUNT_POINT
+            exit 1
+        fi
+    rauc_files=$(find "$MOUNT_POINT" -maxdepth 1 -type f -name "*.raucb")
+    else
+        USB_AS_UPDATER=false
+    fi
+fi
+
+#mounting usb device
+if [ $USB_AS_UPDATER == true ] && [ -n "$rauc_files" ]; then
+    echo "Stopping [ rauc-hawkbit-updater.service ] and starting [ rauc_installer.service ]"
+    systemctl stop rauc-hawkbit-updater.service
+    #export the kernel name of the device to mount it on the rauc_install service
+    #FIXME When doing the update from the rauc-hawkbit-client we might not need to export them, but send a signal directly with them as parameters
+    mkdir /tmp/rauc_install/
+    echo "FD_NAME=$DEVICE_KERNEL_NAME" > /tmp/rauc_install/env_file
+
+    umount $MOUNT_POINT
+    systemctl start rauc_install.service
+    exit 0
+
+else
+    if [ $USB_AS_UPDATER == false ]; then
+        echo "updater device already mounted or partition not valid"
+    else
+        if [ -z "$rauc_files" ]; then
+            echo "RAUC file not found in $USB_PATH, notifying backend of new media"
+            umount $MOUNT_POINT
+            rm -r $MOUNT_POINT
+        fi
+    fi
+    #check if the variable currently updating exists
+    if [ -z "$DEVICE_KERNEL_NAME" ]; then
+        exit 2
+    fi
+    #emiting dbus signal for a new mass storage device
+    busctl --system emit /handlers/massStorage com.Meticulous.Handler.MassStorage NewUSB s "/dev/$DEVICE_KERNEL_NAME"
+    
+    exit 0
+fi

--- a/etc/usb_updater/media_handler.sh
+++ b/etc/usb_updater/media_handler.sh
@@ -44,7 +44,7 @@ if [ $USB_AS_UPDATER == true ] && [ -n "$rauc_files" ]; then
     echo "FD_NAME=$DEVICE_KERNEL_NAME" > /tmp/rauc_install/env_file
 
     umount $MOUNT_POINT
-    systemctl start rauc_install.service
+    systemctl start usb-rauc-install.service
     exit 0
 
 else

--- a/etc/usb_updater/media_rauc_install.sh
+++ b/etc/usb_updater/media_rauc_install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+MOUNT_POINT="/tmp/possible_updater"
+USB_PATH="/dev/$1"
+rauc_file=""
+ERROR_INSTALLING=true
+
+#protect for usb disconnection
+echo "device to mount: $USB_PATH"
+
+if [ ! -b $USB_PATH ]; then
+    echo "USB disconnected, aborting"
+    exit 1
+fi
+
+#mounting usb device
+mount $USB_PATH $MOUNT_POINT
+if [ $? -eq 0 ]; then
+    echo "device mounted"
+else
+    echo "device could not be mounted"
+    exit 2
+fi
+
+rauc_file=$(find "$MOUNT_POINT" -maxdepth 1 -type f -name "*.raucb")
+
+if [ -z "$rauc_file" ]; then
+    echo "RAUC file not found in the usb media"
+    exit 3
+else
+    #checks the status of the rauc-hawknit-updater is stopped
+    rhu_status=$(systemctl status rauc-hawkbit-updater.service | grep inactive)
+    if [ -z "$rhu_status" ]; then
+        echo "hawkbit updater is alive"
+        systemctl stop rauc-hawkbit-updater.service
+    else
+        echo "hawkbit updater is dead"
+    fi
+    # call the InstallBundle() method from rauc using d-bus
+    echo "Installing from rauc bundle"
+
+    while read -r line; do
+        echo "$line"
+        if echo "$line" | grep -q "fail"; then
+            break
+        fi
+
+        if echo "$line" | grep -q "Installing done"; then
+            echo "rauc install completed successfully"
+            ERROR_INSTALLING=false
+            break
+        fi
+
+    done < <(rauc install "$rauc_file")
+
+    if [ ! $ERROR_INSTALLING == true ]; then
+        echo "restarting machine in 5 seconds"
+    fi
+
+    sleep 5
+    echo "unmounting usb"
+    umount $MOUNT_POINT
+
+    # restart the machine when the update finishes
+    if [ $ERROR_INSTALLING == false ]; then
+        #TODO add sound?
+        reboot now
+    else
+        echo "Error installing, not rebooting"
+    fi
+fi

--- a/make-rootfs.sh
+++ b/make-rootfs.sh
@@ -82,14 +82,6 @@ function copy_services() {
 
 }
 
-function copy_usb_handlers_scripts(){
-    
-    #Install shell scripts that handle USB detection and recovery update
-    etc/* ${ROOTFS_DIR}/etc/
-    install -m 0777 etc/usb_updater*.sh \
-        ${ROOTFS_DIR}/etc/usb_updater
-}
-
 function b_copy_components() {
 
     echo "Copying components into existing rootfs"
@@ -168,8 +160,8 @@ function b_copy_components() {
     echo "Installing services"
     copy_services
 
-    echo "Installing usb handlers"
-    copy_usb_handlers_scripts
+    echo "giving permissions to usb handler scripts"
+    chmod 777 ${ROOTFS_DIR}/etc/usb_updater/*.sh
 
     echo "Cleaning"
     systemd-nspawn -D ${ROOTFS_DIR} bash -lc "rm -rf /root/.cache"

--- a/make-rootfs.sh
+++ b/make-rootfs.sh
@@ -77,6 +77,17 @@ function copy_services() {
     ln -sf /lib/systemd/system/rauc.service \
         ${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/rauc.service
 
+    install -m 0644 ${SERVICES_DIR}/usb-rauc-install.service \
+        ${ROOTFS_DIR}/lib/systemd/system
+
+}
+
+function copy_usb_handlers_scripts(){
+    
+    #Install shell scripts that handle USB detection and recovery update
+    etc/* ${ROOTFS_DIR}/etc/
+    install -m 0777 etc/usb_updater*.sh \
+        ${ROOTFS_DIR}/etc/usb_updater
 }
 
 function b_copy_components() {
@@ -156,6 +167,9 @@ function b_copy_components() {
 
     echo "Installing services"
     copy_services
+
+    echo "Installing usb handlers"
+    copy_usb_handlers_scripts
 
     echo "Cleaning"
     systemd-nspawn -D ${ROOTFS_DIR} bash -lc "rm -rf /root/.cache"

--- a/system-services/usb-rauc-install.service
+++ b/system-services/usb-rauc-install.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Meticulous manual updater
+Requires=rauc.service
+
+[Service]
+Type=simple
+EnvironmentFile = /tmp/rauc_install/env_file
+ExecStart=/etc/usb_updater/media_rauc_install.sh $FD_NAME
+Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket

--- a/system-services/usb-rauc-install.service
+++ b/system-services/usb-rauc-install.service
@@ -4,6 +4,5 @@ Requires=rauc.service
 
 [Service]
 Type=simple
-EnvironmentFile = /tmp/rauc_install/env_file
-ExecStart=/etc/usb_updater/media_rauc_install.sh $FD_NAME
+ExecStart=/etc/usb_updater/media_rauc_install.sh
 Environment=DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket


### PR DESCRIPTION
This commit adds the files used to handle USB connection in order to start the recovery update process or notify the backend of the presence of a mass storage device, the files are and do the following

## media_updater.rules

Sets the udev rule that triggers when a mass storage device partition is plugged in the USB. It calls the script `media_handler.sh` passing as parameters the kernel name given to the device and the partition number

## media_handler.sh 

This file checks for the partition number, to only look for rauc bundles in the partition 1 of the devices, if it is not the partition 1 or the `.raucb` file is not present on the root directory, the backend is notified on the presence of the device sending the following dbus signal

`interface=com.Meticulous.Handler.MassStorage, type=signal, member=NewUSB` with attributes
`signature=s, value=dev/<kernelName>`

If the `.raucb` file is found in the root of the device (partition 1), the `rauc-hawkbit-updater.service` is stopped, the kernel name of the device is exported into an environment file to be consumed by the `usb-rauc-install.service` that is then started

## usb-rauc-install.service

This service is provided to detach the process of installation from the udev script execution task by calling `media_rauc_install.sh` with the kernel name provided by the `media_handler.sh` in the environment file

## media_rauc_install.sh

Will install the bundle using rauc and monitor for any error. When the update completes, it restarts the machine after 5 seconds, if any error was encountered, it does not reboot.



 