### PR TITLE
fix(media_handler): usb mass storage handle for recovery update is working

### DIFF
--- a/config/etc/udev/rules.d/media_updater.rules
+++ b/config/etc/udev/rules.d/media_updater.rules
@@ -2,7 +2,7 @@
 
 #According to udevadm info /dev/someUsbStorage -a
 ACTION=="add" \
-, KERNEL=="sd?[1-9]"\
+, KERNEL=="sd?"\
 , SUBSYSTEM=="block"\
 , DRIVERS=="usb-storage"\
 , RUN="/etc/usb_updater/media_handler.sh %k %n"

--- a/config/etc/usb_updater/media_handler.sh
+++ b/config/etc/usb_updater/media_handler.sh
@@ -1,88 +1,37 @@
 #!/bin/bash
 
-MOUNT_POINT="/tmp/possible_updater"
+UPDATING_FLAG_FILE="/tmp/updating"
 DEVICE_KERNEL_NAME="$1"
-PARTITION_NUMBER=$2
 
-USB_PATH="/dev/$DEVICE_KERNEL_NAME"
-
-USB_AS_UPDATER=true
-rauc_files=""
-
-#if the mount point exists, it is being updated, discard this usb as updater device
-if [ -d $MOUNT_POINT ]; then
-    USB_AS_UPDATER=false
-else
-
-    echo "partition number received: $PARTITION_NUMBER"
-
-    if [ "$PARTITION_NUMBER" == "1" ]; then
-        mkdir $MOUNT_POINT
-        echo "attempting to mount: $USB_PATH"
-        mount $USB_PATH $MOUNT_POINT 1>&2
-        error_mounting="$?"
-        if [ $error_mounting == "0" ]; then
-            echo "device mounted"
-        else
-            echo "device $USB_PATH could not be mounted: $error_mounting"
-            rm -r $MOUNT_POINT
-            exit 1
-        fi
-    rauc_files=$(find "$MOUNT_POINT" -maxdepth 1 -type f -name "*.raucb")
-    else
-        USB_AS_UPDATER=false
-    fi
+#if a partition is mounted
+if [ -f $UPDATING_FLAG_FILE ]; then
+    echo "machine is updating"
+    exit 1
 fi
 
-#mounting usb device
-if [ $USB_AS_UPDATER == true ] && [ -n "$rauc_files" ]; then
-    echo "Stopping [ rauc-hawkbit-updater.service ] and starting [ rauc_installer.service ]"
-    systemctl stop rauc-hawkbit-updater.service
-    #export the kernel name of the device to mount it on the rauc_install service
-    #FIXME When doing the update from the rauc-hawkbit-client we might not need to export them, but send a signal directly with them as parameters
+echo "device to analyze: $DEVICE_KERNEL_NAME"
 
-    umount $MOUNT_POINT
-    systemctl start usb-rauc-install.service
+systemctl start usb-rauc-install.service
 
-    #wait for the service to be up, and send the data through a dbus signal
-    sleep 2
-    busctl --system emit /handlers/massStorage com.Meticulous.Handler.MassStorage Updater s "/dev/$DEVICE_KERNEL_NAME"
-    
-    #wait for the service to respond
-    timeout --foreground 2 bash -c '
-    while read -r line ; do
-       echo $line
-       if [ -n "$(echo $line | grep /handlers/Updater)" ]; then
-           echo "usb-rauc-install.service is up"
-           break
-       fi
-    done < <(dbus-monitor --system "interface=com.Meticulous.Handler.Updater, member=Alive")
-    '
+#wait for the service to be up, and send the data through a dbus signal
+sleep 1
+busctl --system emit /handlers/massStorage com.Meticulous.Handler.MassStorage Updater s "$DEVICE_KERNEL_NAME"
 
-    if [ $? -eq 124 ]; then
-        echo "usb-rauc-install.service didnt respond"
-        exit 3
-    else
-        echo "usb-rauc-install.service started"
-        exit 0
+#wait for the service to respond
+timeout --foreground 5 bash -c '
+while read -r line ; do
+    echo $line
+    if [ -n "$(echo $line | grep /handlers/Updater)" ]; then
+        echo "usb-rauc-install.service is up"
+        break
     fi
+done < <(dbus-monitor --system "interface=com.Meticulous.Handler.Updater, member=Alive")
+'
+
+if [ $? -eq 124 ]; then
+    echo "usb-rauc-install.service didnt respond"
+    exit 2
 else
-    if [ $USB_AS_UPDATER == false ]; then
-        echo "updater device already mounted or partition not valid"
-    else
-        if [ -z "$rauc_files" ]; then
-            echo "RAUC file not found in $USB_PATH, cleaning"
-            umount $MOUNT_POINT
-            rm -r $MOUNT_POINT
-        fi
-    fi
-    #check if the variable currently updating exists
-    if [ -z "$DEVICE_KERNEL_NAME" ]; then
-        exit 2
-    fi
-    #emiting dbus signal for a new mass storage device
-    echo "Notifying backend of new media"
-    busctl --system emit /handlers/massStorage com.Meticulous.Handler.MassStorage NewUSB s "/dev/$DEVICE_KERNEL_NAME"
-    
+    echo "usb-rauc-install.service started"
     exit 0
 fi

--- a/config/etc/usb_updater/media_rauc_install.sh
+++ b/config/etc/usb_updater/media_rauc_install.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 
-MOUNT_POINT="/tmp/possible_updater"
+MOUNT_POINT="/mnt/possible_updater"
+UPDATING_FLAG_FILE="/tmp/updating"
 USB_PATH=""
-rauc_file=""
+rauc_files=""
 ERROR_INSTALLING=true
+PARTITION_NAME=""
 
 #wait for the name of the device that has the update bundle
-USB_PATH=$(timeout 10 bash -c '
+USB_PATH=$(timeout 6 bash -c '
 while read -r line ; do
-    if [ -n "$(echo $line | grep /dev/)" ]; then
+    if [ -n "$(echo $line | grep -E sd. )" ]; then
         busctl --system emit /handlers/Updater com.Meticulous.Handler.Updater Alive
         echo "$line"
         break
     fi
 done < <(dbus-monitor --system "interface=com.Meticulous.Handler.MassStorage, member=Updater")')
 
-# echo "received = $USB_PATH"
 USB_PATH=$(echo $USB_PATH | awk '{print $2}' | tr -d '\n\r" ' )
 
 if [ -z $USB_PATH ]; then
@@ -24,67 +25,75 @@ if [ -z $USB_PATH ]; then
 fi
 
 #protect for usb disconnection
-echo "device to mount: $USB_PATH"
-
-if [ ! -b $USB_PATH ]; then
+if [ ! -b "/dev/$USB_PATH" ]; then
     echo "USB disconnected, aborting"
     exit 1
 fi
 
-#mounting usb device
-mount $USB_PATH $MOUNT_POINT
-if [ $? -eq 0 ]; then
-    echo "device mounted"
-else
-    echo "device could not be mounted"
-    exit 2
-fi
+#find the rauc file in any partition of the plugged in device
+mkdir $MOUNT_POINT
+for PARTITION_NAME in $(ls /dev/ | grep -E $USB_PATH[1-9]+); do
 
-rauc_file=$(find "$MOUNT_POINT" -maxdepth 1 -type f -name "*.raucb")
-
-if [ -z "$rauc_file" ]; then
-    echo "RAUC file not found in the usb media"
-    exit 3
-else
-    #checks the status of the rauc-hawknit-updater is stopped
-    rhu_status=$(systemctl status rauc-hawkbit-updater.service | grep inactive)
-    if [ -z "$rhu_status" ]; then
-        echo "hawkbit updater is alive"
-        systemctl stop rauc-hawkbit-updater.service
+    FILE_DESCRIPTOR="/dev/$PARTITION_NAME"
+    umount $FILE_DESCRIPTOR #if automount mounted it, later maybe make use of automount
+    mount $FILE_DESCRIPTOR $MOUNT_POINT 1>&2
+    error_mounting="$?"
+    if [ $error_mounting == "0" ]; then
+        echo "device mounted"
     else
-        echo "hawkbit updater is dead"
+        echo "device $FILE_DESCRIPTOR could not be mounted: $error_mounting"
+        continue
     fi
-    # call the InstallBundle() method from rauc using d-bus
-    echo "Installing from rauc bundle"
-    busctl --system emit /handlers/MassStorage com.Meticulous.Handler.MassStorage RecoveryUpdate
+    rauc_files="$(find "$MOUNT_POINT" -maxdepth 1 -type f -name "*.raucb")"
+    if [ -n "$rauc_files" ]; then
 
+        echo "starting recovery update service"
+        touch $UPDATING_FLAG_FILE
+        systemctl stop rauc-hawkbit-updater.service
+        busctl --system emit /handlers/MassStorage com.Meticulous.Handler.MassStorage RecoveryUpdate
+        break
+    else
+        #notify backend of new media
+        echo "Notifying backend of new media"
+        busctl --system emit /handlers/massStorage com.Meticulous.Handler.MassStorage NewUSB s "/dev/$PARTITION_NAME"
+    fi
+    umount $MOUNT_POINT
+done 
+
+if [ -n "$rauc_files" ]; then
     while read -r line; do
         echo "$line"
         if echo "$line" | grep -q "fail"; then
             break
         fi
-
         if echo "$line" | grep -q "Installing done"; then
             echo "rauc install completed successfully"
             ERROR_INSTALLING=false
             break
         fi
 
-    done < <(rauc install "$rauc_file")
+    done < <(rauc install "$rauc_files")
 
-    if [ ! $ERROR_INSTALLING == true ]; then
+    if [ $ERROR_INSTALLING == false ]; then
         echo "restarting machine in 5 seconds"
     fi
 
-    sleep 5
+    sleep 2
     echo "unmounting usb"
     umount $MOUNT_POINT
+    rm -r $MOUNT_POINT
 
     # restart the machine when the update finishes
     if [ $ERROR_INSTALLING == false ]; then
-        #TODO add sound?
+        sleep 3
         reboot now
     else
-        echo "Error installing, not rebooting"
+        echo "Error while installing, not rebooting"
+        systemctl restart rauc-hawkbit-updater.service
+        rm $UPDATING_FLAG_FILE
+    fi
+else
+    if [ -d $MOUNT_POINT ]; then
+        rm -r $MOUNT_POINT
     fi
 fi


### PR DESCRIPTION
## media_handler.sh 
The purpose of media_handler.sh now is just to start the usb-rauc-install.service and provision it the name of the device that triggered the udev rule, with this the udev rule executable does not have to mount and look for files before, as it is now done by the service itself. If there is a recovery update going on, the script will not try to start the service, so it will just "reject" any new usb drive

## media_rauc_install.sh 
This script now is in charge of looking for the rauc bundle and deciding to start a recovery update or just notify the backend of the new media. It can look for the bundle in any partition of the plugged in device. If by any reason, there is bundles in more than one partition, it will install the first bundle found -from the partition with the lowest number-

## media_updater.rules
Now it catches the name of the whole device instead of only the partitions, in fact now it ignores the partitions, so it is only triggered once for every device despite the its number of partitions