### PR TITLE
udev: Remove DRIVER filter

### DIFF
--- a/config/etc/udev/rules.d/media_updater.rules
+++ b/config/etc/udev/rules.d/media_updater.rules
@@ -4,5 +4,4 @@
 ACTION=="add" \
 , KERNEL=="sd?"\
 , SUBSYSTEM=="block"\
-, DRIVERS=="usb-storage"\
 , RUN="/etc/usb_updater/media_handler.sh %k %n"


### PR DESCRIPTION
More modern USB-3 devices no longer use the usb-storage driver but instead are running with the buildin mass-storage driver. Remove that line to allow for more devices to be recognized.

udev dump:
```
udevadm info /dev/sda1 -a

Udevadm info starts with the device specified by the devpath and then
walks up the chain of parent devices. It prints for every device
found, all possible attributes in the udev rules key format.
A rule to match, can be composed by the attributes of the device
and the attributes from one single parent device.

  looking at device '/devices/platform/soc@0/32c00000.bus/32e40000.usb/ci_hdrc.0/usb1/1-1/1-1.1/1-1.1:1.0/host0/target0:0:0/0:0:0:0/block/sda/sda1':
    KERNEL=="sda1"
    SUBSYSTEM=="block"
    DRIVER==""
    ATTR{alignment_offset}=="0"
    ATTR{discard_alignment}=="0"
    ATTR{inflight}=="       0        0"
    ATTR{partition}=="1"
    ATTR{power/control}=="auto"
    ATTR{power/runtime_active_time}=="0"
    ATTR{power/runtime_status}=="unsupported"
    ATTR{power/runtime_suspended_time}=="0"
    ATTR{ro}=="0"
    ATTR{size}=="240328672"
    ATTR{start}=="32"
    ATTR{stat}=="    9023    29061  1771477    28335        6        0        6       25        0    43612    28361        0        0        0        0        0        0"

  looking at parent device '/devices/platform/soc@0/32c00000.bus/32e40000.usb/ci_hdrc.0/usb1/1-1/1-1.1/1-1.1:1.0/host0/target0:0:0/0:0:0:0/block/sda':
    KERNELS=="sda"
    SUBSYSTEMS=="block"
    DRIVERS==""
    ATTRS{alignment_offset}=="0"
    ATTRS{capability}=="1"
    ATTRS{discard_alignment}=="0"
    ATTRS{diskseq}=="32"
    ATTRS{events}=="media_change"
    ATTRS{events_async}==""
    ATTRS{events_poll_msecs}=="-1"
    ATTRS{ext_range}=="256"
    ATTRS{hidden}=="0"
    ATTRS{inflight}=="       0        0"
    ATTRS{integrity/device_is_integrity_capable}=="0"
    ATTRS{integrity/format}=="none"
    ATTRS{integrity/protection_interval_bytes}=="0"
    ATTRS{integrity/read_verify}=="0"
    ATTRS{integrity/tag_size}=="0"
    ATTRS{integrity/write_generate}=="0"
    ATTRS{mq/0/cpu_list}=="0, 1, 2, 3"
    ATTRS{mq/0/nr_reserved_tags}=="0"
    ATTRS{mq/0/nr_tags}=="30"
    ATTRS{power/control}=="auto"
    ATTRS{power/runtime_active_time}=="0"
    ATTRS{power/runtime_status}=="unsupported"
    ATTRS{power/runtime_suspended_time}=="0"
    ATTRS{queue/add_random}=="1"
    ATTRS{queue/chunk_sectors}=="0"
    ATTRS{queue/dax}=="0"
    ATTRS{queue/discard_granularity}=="0"
    ATTRS{queue/discard_max_bytes}=="0"
```