### PR TITLE
feat(reset-password):Add reset-password script and service

### DIFF
--- a/config/usr/local/sbin/reset-password.sh
+++ b/config/usr/local/sbin/reset-password.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+FIRST_BOOT_FLAG="/meticulous-user/first_password_changed"
+if [ ! -f "$FIRST_BOOT_FLAG" ]; then
+    chage -d 0 root
+    touch "$FIRST_BOOT_FLAG"
+fi

--- a/system-services/meticulous-reset-password.service
+++ b/system-services/meticulous-reset-password.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=First Boot Root Password Change
+After=local-fs.target
+ConditionPathExists=!/meticulous-user/first_password_changed
+[Service]
+Type=oneshot
+StandardInput=tty
+StandardOutput=tty
+TTYPath=/dev/tty1
+ExecStart=/usr/local/sbin/reset-password.sh
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
What I do to reset the password is force the current password to expire, which triggers a mechanism in Debian that prompts for a new password to be entered.
A flag is set in meticulous-user to ensure this mechanism is only activated once.