### PR TITLE
meticulous-brightness.service: Don't hardcode the max brightness

### DIFF
--- a/system-services/meticulous-brightness.service
+++ b/system-services/meticulous-brightness.service
@@ -4,7 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash -c 'echo 4095 > /sys/class/backlight/backlight/brightness'
+ExecStart=/bin/bash -c 'cat /sys/class/backlight/backlight/max_brightness > /sys/class/backlight/backlight/brightness'
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
The usage of a max brightness of 4096 requires us to always have these brightness levels available now and in the future. As we will be migrating to different kernels with different backlight implementations in the future we shouldn't hardcode these values any longer.
NOTE: This should also be implemented in the backend where the brightness for idle is also hardcoded