### PR TITLE
update rauc config file: 

### DIFF
--- a/config/etc/hawkbit/config.conf.template
+++ b/config/etc/hawkbit/config.conf.template
@@ -22,3 +22,5 @@
   update_channel            = __UPDATE_CHANNEL__
   boot_mode                 = __BOOT_MODE__
   serial                    = __SERIAL__
+  boot_partition            = __BOOTED__
+  build_date                = __BUILD_DATE__

--- a/config/etc/hawkbit/create_config.sh
+++ b/config/etc/hawkbit/create_config.sh
@@ -2,8 +2,10 @@
 
 if grep -q "root=/dev/mmcblk1" /proc/cmdline; then
   export boot_mode="sdcard";
+  boot_partition="sdcard"  #get boot partition
 else
   export boot_mode="emmc";
+  boot_partition=$(rauc status --output-format=json-pretty | grep -oP '"booted" : "\K[^"]*' || echo UNKNOWN)  #get boot partition
 fi;
 
 echo "Boot mode is ${boot_mode}"
@@ -18,7 +20,12 @@ if [ ! -z "$(which met-config)" ]; then
   serial=$(met-config get .system.serial)
 fi
 
+build_date=$(cat /opt/ROOTFS_BUILD_DATE || echo UNKNOWN)                                          #get booted image build date
+
+
 sed -i "s/__TARGET_NAME__/$(hostname)/" /etc/hawkbit/config.conf
 sed -i "s/__BOOT_MODE__/${boot_mode}/" /etc/hawkbit/config.conf
 sed -i "s/__UPDATE_CHANNEL__/${update_channel}/" /etc/hawkbit/config.conf
 sed -i "s/__SERIAL__/${serial}/" /etc/hawkbit/config.conf
+sed -i "s/__BOOTED__/${boot_partition}/" /etc/hawkbit/config.conf
+sed -i "s/__BUILD_DATE__/${build_date}/" /etc/hawkbit/config.conf


### PR DESCRIPTION
Two new attributes are sent to the hawkbit service
 * boot_partition
 * build_date

`boot_partition` indicates the active partition chosen to boot into by rauc being A and B the possibilities
`build_date` indicates the date in which the booted image was built at

![image](https://github.com/user-attachments/assets/73693c77-52d9-4287-b9c7-7dbc9642a49d)
