### PR TITLE
feat: keep the latest images on server

### DIFF
--- a/misc/hawkbit-upload.py
+++ b/misc/hawkbit-upload.py
@@ -384,8 +384,9 @@ class HawkbitMgmtClient:
         module_ids: list = [],
         dist_type: str = "os",
     ):
-        existing_dist = self.get_distributionsets_by_name(name)[0]
-        if existing_dist:
+        named_distributions = self.get_distributionsets_by_name(name)
+        if named_distributions:
+            existing_dist = named_distributions[0]
             print(
                 f"Distribution set '{name}' already exists as ID={existing_dist['id']}. Using existing distribution. Updating version!"
             )

--- a/misc/hawkbit-upload.py
+++ b/misc/hawkbit-upload.py
@@ -786,7 +786,6 @@ class HawkbitMgmtClient:
         existing_module = self.get_softwaremodule_by_name(name, version=self.version)
         if existing_module:
             print(f"module {name} with version {self.version} already exists, using that")
-            self.id["newSoftwaremodule"] = response[0]['id']
             return existing_module['id']
         
         data = [

--- a/misc/hawkbit-upload.py
+++ b/misc/hawkbit-upload.py
@@ -814,9 +814,9 @@ class HawkbitMgmtClient:
         new_module_id = self.push_new_os_softwaremodule(softwaremodule_name)
         
         #define the corresponding data for the distribution set
-        assert isinstance(module_ids, list)
         modules_list = [new_module_id]
-        modules_list.extend(module_ids)
+        if isinstance(module_ids, list):            
+            modules_list.extend(module_ids)
         
         data = [
             {


### PR DESCRIPTION
We want to have an archive of the latest versions for each distribution set, so that we can access and deploy them without needing to rebuild them every time.

To achieve that we now treat every distribution deployment as a stack push allowing us to keep the most recent image on its head and purging those images that are older and exceed the allowd "stack size".

The "stack size" is set in the global variable `MAX_IMAGES_ON_SERVER`

## New functions introduced
 + push_new_os_softwaremodule():
    - As there is meant to be only 1 "os" type software module per distribution, this creates it directly as an "os" type, allways creates a new SM, does not modify any existing one

 + push_new_distribution_set_with_os():
    - Creates a distribution set and immediately links it to an also new "os" type SM. Also handles uploading the artifact if a filename is provided

 + purge_distributionsets():
    - Clears all content related to the distributionset ids passed to it, this includes deleting all software modules and its corresponding artifacts

 + sort_distributions_by_version():
    - Returns a sorted array of the distributions that share the name passed to it with the most recent in the position 0

## Functions modified:
 + get_distributionset_by_name():
   - Changed to get_distributionsets_by_name() and now it returns an array of all the distributions that share the name provided

 + get_softwaremodule_by_name():
    - Refactored, should not change behaviour