### PR TITLE
fix: usb does not start OS Upgrade if fd is "sd*" with no number

### DIFF
--- a/config/etc/usb_updater/media_rauc_install.sh
+++ b/config/etc/usb_updater/media_rauc_install.sh
@@ -32,7 +32,10 @@ fi
 
 #find the rauc file in any partition of the plugged in device
 mkdir $MOUNT_POINT
-for PARTITION_NAME in $(ls /dev/ | grep -E $USB_PATH[1-9]+); do
+
+declare -A devices
+devices=$(ls /dev/ | grep -E "$USB_PATH([1-9]+)?")
+for PARTITION_NAME in $devices; do
 
     FILE_DESCRIPTOR="/dev/$PARTITION_NAME"
     umount $FILE_DESCRIPTOR #if automount mounted it, later maybe make use of automount


### PR DESCRIPTION
if the kernel sets the fd for the massStorage partition in which the bundle is present to "sd*" with no trailing number like "sda1", the media_rauc_install.sh did not recgnize it. This commit fixes the regex in charge of that