### PR TITLE
Chore/manual skip hawkbit upload

### DIFF
--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -8,6 +8,10 @@ on:
       image:
         description: Which image to build
         default: nightly
+      skip_emmc_upload_to_hawkbit:
+        description: Skip uploading EMMC bundle to hawkBit (manual runs only)
+        type: boolean
+        default: true
 
 permissions:
   contents: write
@@ -259,6 +263,7 @@ jobs:
   deploy-emmc-bundle:
     name: Upload EMMC image to hawkbit
     needs: build-bundle
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.skip_emmc_upload_to_hawkbit != true }}
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout code

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -9,7 +9,7 @@ on:
         description: Which image to build
         default: nightly
       skip_emmc_upload_to_hawkbit:
-        description: Skip uploading EMMC bundle to hawkBit (manual runs only)
+        description: Skip uploading EMMC bundle to hawkBit
         type: boolean
         default: true
 


### PR DESCRIPTION
This PR adds a new boolean input to the Build image workflow for manual runs: skip_emmc_upload_to_hawkbit (default true). As a result, the EMMC bundle upload to Hawkbit is skipped by default when the workflow is triggered manually. Scheduled runs keep the existing behavior and still execute the upload.

<img width="473" height="423" alt="image" src="https://github.com/user-attachments/assets/bc6e68ec-0810-4227-a2b2-039ac253cab9" />
