### PR TITLE
feat: add the version number to the changelog github page

### DIFF
--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -38,6 +38,11 @@ jobs:
     name: Generate version info and changelog
     runs-on: ubuntu-24.04
     steps:
+
+      - name: Generate build number
+        run: |
+          echo "BUILD_VERSION_NUMBER=$(./generate_image_version.sh "${{github.run_number}}" "${{ inputs.image || 'nightly' }}")" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -51,7 +56,7 @@ jobs:
 
       - name: Generate build info and changelog
         run: |
-          ./generate-build-info.sh ${{ inputs['image'] || 'nightly' }}
+          ./generate-build-info.sh ${{ inputs['image'] || 'nightly' }} $BUILD_VERSION_NUMBER          
 
       - name: Upload version-info artifact
         uses: actions/upload-artifact@v4
@@ -175,7 +180,7 @@ jobs:
     - name: Generate build number and writing it to to image-build-version
       run: |
         echo -n "Image build version: " >> $GITHUB_STEP_SUMMARY
-        ./generate_image_version.sh "${{github.run_number}}" "${{ inputs.image || 'nightly' }}" | sudo tee ./image-build-version >> $GITHUB_STEP_SUMMARY
+        echo "$BUILD_VERSION_NUMBER" | sudo tee ./image-build-version >> $GITHUB_STEP_SUMMARY
 
     - name: Build rootfs
       run: |

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -37,14 +37,19 @@ jobs:
   generate-version-info:
     name: Generate version info and changelog
     runs-on: ubuntu-24.04
+    outputs:
+      build_version_number: ${{ steps.generate-build-number.outputs.build_version_number }}
     steps:
-
-      - name: Generate build number
-        run: |
-          echo "BUILD_VERSION_NUMBER=$(./generate_image_version.sh "${{github.run_number}}" "${{ inputs.image || 'nightly' }}")" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Generate build number
+        id: generate-build-number
+        run: |
+          BUILD_VERSION_NUMBER="$(./generate_image_version.sh "${{ github.run_number }}" "${{ inputs.image || 'nightly' }}")"
+          echo "BUILD_VERSION_NUMBER=${BUILD_VERSION_NUMBER}" >> "$GITHUB_ENV"
+          echo "build_version_number=${BUILD_VERSION_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Git authentication
         run: |
@@ -73,6 +78,8 @@ jobs:
     needs: 
       - build-components
       - generate-version-info
+    env:
+      BUILD_VERSION_NUMBER: ${{ needs.generate-version-info.outputs.build_version_number }}
     steps:
 
     - name: Checkout repository

--- a/generate-build-info.sh
+++ b/generate-build-info.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-# generate-build-info.sh <image_name>
+# generate-build-info.sh <image_name> [GH_BUILD_NUMBER]
 #
 # Generates:
 #   1. components/repo-info/summary.txt   (consumed by make-rootfs.sh)
@@ -9,12 +9,19 @@ set -eo pipefail
 #   3. images/changes/<channel>/<timestamp>.changelog.yaml
 #      Contains a full version snapshot AND a diff against the previous build.
 
+#      GH_BUILD_NUMBER is optional parameter passed when run in a github action
+
 if [ $# -lt 1 ]; then
-    echo "Usage: $0 <image_name>"
+    echo "Usage: $0 <image_name> [GH_BUILD_NUMBER]"
     exit 1
 fi
 
 IMAGE_NAME="$1"
+BUILD_NUMBER="NOT PROVIDED"
+
+if [ -n "$2" ]; then
+    BUILD_NUMBER="$2"
+fi
 
 source config.sh
 
@@ -153,6 +160,7 @@ yaml_escape() {
 {
     echo "channel: \"${IMAGE_NAME}\""
     echo "timestamp: \"${TIMESTAMP}\""
+    echo "build-version: \"${BUILD_NUMBER}\""
 
     # Write full version snapshot
     echo "versions:"

--- a/generate-changelog-html.py
+++ b/generate-changelog-html.py
@@ -27,6 +27,7 @@ def parse_changelog_yaml(filepath):
     """
     result = {
         "channel": "",
+        "build-version": None,
         "timestamp": "",
         "versions": {},
         "changes": {},
@@ -49,6 +50,10 @@ def parse_changelog_yaml(filepath):
             if not line.startswith(" ") and not line.startswith("\t"):
                 if line.startswith("channel:"):
                     result["channel"] = _extract_value(line)
+                    current_section = None
+                    current_component = None
+                if line.startswith("build-version:"):
+                    result["build-version"] = _extract_value(line)
                     current_section = None
                     current_component = None
                 elif line.startswith("timestamp:"):
@@ -248,7 +253,7 @@ def generate_html(changes_dir, output_path):
     align-items: center;
     margin-bottom: 0.75rem;
   }
-  .build-timestamp {
+  .build-info-header {
     font-size: 0.9rem;
     color: var(--text-muted);
     font-family: monospace;
@@ -339,13 +344,15 @@ def generate_html(changes_dir, output_path):
                     html_parts.append('<div class="build-entry">')
                     html_parts.append('<div class="build-header">')
                     ts = entry.get("timestamp", "unknown")
+                    build_version = entry.get("build-version", "not recorded")
                     display_ts = ts.replace("T", " ").replace("-", ":", 2) if "T" in ts else ts
                     # Only replace the time-separator dashes, not the date ones
                     # Format: 2026-02-26T00-00-00 -> 2026-02-26 00:00:00
                     if "T" in ts:
                         date_part, _, time_part = ts.partition("T")
                         display_ts = f"{date_part} {time_part.replace('-', ':')}"
-                    html_parts.append(f'<span class="build-timestamp">{_html_escape(display_ts)}</span>')
+                    build_header = f"{display_ts} - version: {build_version if build_version else 'not recorded'}"
+                    html_parts.append(f'<span class="build-info-header">{_html_escape(build_header)}</span>')
                     html_parts.append("</div>")
 
                     changes = entry.get("changes", {})


### PR DESCRIPTION
on the build-nightly-image.yml generate the image version at the start of `generate-version-info` step and save it into `BUILD_VERSION_NUMBER` env variable for later use.

pass the `BUILD_VERSION_NUMBER` to generate-build-info.sh as a second optional parameter so the script can add it to the changelog.yaml files as `build-version: $BUILD_VERSION_NUMBER`

on the `generate-changelog-html.py` also look for the "build-version" tag and add it to the header where the build timestamp is places

## Example of rendered website
<img width="950" height="892" alt="image" src="https://github.com/user-attachments/assets/76b83964-c340-423d-ba4d-50ddef95595b" />
