### PR TITLE
Update nginx proxy configuration to allow compression

### DIFF
--- a/config/etc/nginx/sites-available/default
+++ b/config/etc/nginx/sites-available/default
@@ -56,6 +56,12 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_read_timeout 1800s;
+
+        # Allow JSON compression for proxied API responses
+        gzip on;
+        gzip_proxied any;
+        gzip_types application/json;
+        gzip_min_length 1000;  # skip tiny responses
     }
 
 	location ~* ^/health {


### PR DESCRIPTION
This change updates the nginx configuration for the /api and /socket.io paths to allow the nginx proxy to compress JSON responses if the client asks for compression.

JSON is highly compressible. It looks like this reduces response sizes by about 90% (as in 1/10th the size). In my experience, on an iffy 2.4 GHz network, this results in API responses that are SO MUCH faster. My Meticulous has a very weak connection sometimes. Currently, I am seeing this, typically:

```
time curl "http://$meticulous_ip/api/v1/history?max_results=20" -Haccept:application/json  > /dev/null
```
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3459k  100 3459k    0     0   161k      0  0:00:21  0:00:21 --:--:--  112k
curl "http://$meticulous_ip/api/v1/history?max_results=20"  > /dev/null  0.04s user 0.15s system 0% cpu 21.492 total
```

That is, 20+ seconds. With `--compressed` passed:

```
time curl "http://$meticulous_ip/api/v1/history?max_results=20" -Haccept:application/json --compressed > /dev/null
```
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  355k    0  355k    0     0   138k      0 --:--:--  0:00:02 --:--:--  138k
curl "http://$meticulous_ip/api/v1/history?max_results=20"  --compressed >   0.02s user 0.02s system 1% cpu 2.589 total
```

That is, about a tenth of the time spent waiting, and MUCH more consistent (less air time, less frames to resend).