### PR TITLE
Disable Wi-Fi power-save by default

### DIFF
--- a/config/etc/NetworkManager/conf.d/99-wifi-powersave-off.conf
+++ b/config/etc/NetworkManager/conf.d/99-wifi-powersave-off.conf
@@ -1,0 +1,2 @@
+[connection]
+wifi.powersave = 2


### PR DESCRIPTION
## Summary

Wi-Fi power-save mode is enabled by default in the current image. In moderately noisy 2.4 GHz environments this causes severe packet loss on the managed `wlan0` interface, making the Meticulous API unreliable for remote apps and integrations.

This PR adds a NetworkManager drop-in that explicitly disables Wi-Fi power-save. The machine is mains-powered, so there is no battery-life trade-off - only latency and reliability benefits.

## Reproduction

Tested on firmware `6.12.60-gf7e1dec23d55 #2 SMP PREEMPT` in a dense apartment-building RF environment (~80 visible neighbor SSIDs on 2.4 GHz).

API endpoint tested:
`GET http://<machine>/api/v1/history?orderby=date&sort=desc&maxresults=10&dumpdata=true`

| Configuration | API total time | Wireless packet loss¹ |
|---|---|---|
| `power_save: on` (current default) | 22–97 s | 27 % |
| `power_save: off` | 18–25 s | **0 %** |

¹ 100-packet ping flood from the upstream AP to `wlan0`, 100 ms interval.

Latency on localhost (`curl http://localhost/...` over SSH on the machine itself) is ~2 s in both cases, confirming the bottleneck is purely wireless.

## Mechanism

With power-save on, the device sleeps between beacon intervals (~100 ms) and the AP buffers downstream packets. When the AP is also retrying due to interference, retries accumulate against a sleeping client and time out. The bimodal RTT pattern (1 ms / 80 ms alternating) confirms the wake-cycle interaction.

NetworkManager `wifi.powersave` values:
- `0` - default
- `1` - ignore (don't touch)
- `2` - **disable**
- `3` - enable

## Verification

### Setting is applied after boot
```
$ iw dev wlan0 get power_save
Power save: off
```

### Wireless link quality
100-packet ping flood from the upstream AP to the machine's `wlan0` (100 ms interval).

**Before (power-save on):**
```
sent=100 received=73 packet-loss=27%
min-rtt=1.4ms avg-rtt=28.7ms max-rtt=91.5ms
```

Excerpt showing the characteristic **bimodal pattern** — successful pings alternate between ~1 ms (device **awake**) and ~60–90 ms (**waited for next wake interval**); timeouts are packets that missed the wake window entirely:
```
SEQ   RTT
80   58.4 ms
81    1.3 ms
82   70.3 ms
83    1.6 ms
84   timeout
85   71.1 ms
86    2.1 ms
87   66.3 ms
```

**After (power-save off):**
```
sent=100 received=100 packet-loss=0%
min-rtt=1.4ms avg-rtt=16.7ms max-rtt=91.5ms
```

RTTs no longer cluster at the ~80 ms wake-cycle boundary.

### API endpoint response time

Same `curl` benchmark, 7 consecutive runs from a laptop on the same network:

**Before:**
```
total=81.9s
total=97.6s
total=43.5s
total=55.8s
total=37.3s
total=35.5s
total=22.6s
```

**After:**
```
total=18.9s
total=25.7s
total=25.3s
total=22.5s
total=20.0s
total=24.1s
total=25.0s
```

Localhost on the machine itself (`curl http://localhost/...` over SSH) is ~2 s in both cases, confirming the remaining latency is downstream throughput on the weak wireless link, not application-side.



## Notes

- Only `wlan0` is managed by NetworkManager (`uap0` and `wfd0` are listed in `99-iw61x-unmanaged-devices.conf`), so this setting effectively applies only to the managed home-network connection.
- The `99-` filename prefix ensures it loads last and overrides any earlier defaults, matching the existing convention in `conf.d/`.
- Verified the change persists across reboots - NetworkManager applies it on every connection activation.
