### PR TITLE
Remove image build cron

### DIFF
--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -1,8 +1,6 @@
 name: Build image
 
 on:
-  schedule:
-    - cron: '0 0 * * *'  # Nightly at midnight
   workflow_dispatch:  # Allows manual triggering
     inputs:
       image:


### PR DESCRIPTION
## Summary
- Remove the scheduled nightly cron trigger from the main image build workflow.
- Keep the workflow available for manual `workflow_dispatch` runs.

## Validation
- Parsed `.github/workflows/build-nightly-image.yml` with Ruby YAML.
- Ran `git diff --check`.
- Verified no active `cron` remains in `.github/workflows/build-nightly-image.yml`.
