### PR TITLE
Persist IW612 region outside user data

### DIFF
--- a/rauc-config/rootfs_hooks.sh
+++ b/rauc-config/rootfs_hooks.sh
@@ -22,6 +22,14 @@ case "$1" in
                 cp -rv /etc/ssh/ssh_host_*_key*   "$RAUC_SLOT_MOUNT_POINT/etc/ssh"
                 cp -rv /etc/passwd /etc/shadow "$RAUC_SLOT_MOUNT_POINT/etc/"
 
+                if [ -e /etc/meticulous/iw612-region.conf ]; then
+                        mkdir -p "$RAUC_SLOT_MOUNT_POINT/etc/meticulous"
+                        cp -rv /etc/meticulous/iw612-region.conf "$RAUC_SLOT_MOUNT_POINT/etc/meticulous/"
+                elif [ -e /meticulous-user/iw612-region.conf ]; then
+                        mkdir -p "$RAUC_SLOT_MOUNT_POINT/etc/meticulous"
+                        cp -rv /meticulous-user/iw612-region.conf "$RAUC_SLOT_MOUNT_POINT/etc/meticulous/"
+                fi
+
                 if [ -e /root/.ssh/authorized_keys ]; then
                         mkdir -p "$RAUC_SLOT_MOUNT_POINT/root/.ssh"
                         cp -rv /root/.ssh/authorized_keys "$RAUC_SLOT_MOUNT_POINT/root/.ssh/"

--- a/scripts/met-iw612-set-region
+++ b/scripts/met-iw612-set-region
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 firmware_dir="${MET_IW612_FIRMWARE_DIR:-/lib/firmware/nxp}"
-state_dir="${MET_IW612_STATE_DIR:-/meticulous-user}"
+state_dir="${MET_IW612_STATE_DIR:-/etc/meticulous}"
 state_file="${MET_IW612_STATE_FILE:-${state_dir}/iw612-region.conf}"
+legacy_state_file="${MET_IW612_LEGACY_STATE_FILE:-/meticulous-user/iw612-region.conf}"
 mod_para="${MET_IW612_MOD_PARA:-${firmware_dir}/var_wifi_mod_para.conf}"
 wifi_control="${MET_IW612_WIFI_CONTROL:-/etc/wifi/variscite-wifi}"
 
@@ -96,11 +97,22 @@ profile_for_input() {
 read_state_value() {
     local key="$1"
 
+    migrate_legacy_state
+
     if [ ! -r "${state_file}" ]; then
         return 0
     fi
 
     awk -F= -v key="${key}" '$1 == key { print $2 }' "${state_file}" | tail -n 1
+}
+
+migrate_legacy_state() {
+    if [ -r "${state_file}" ] || [ ! -r "${legacy_state_file}" ]; then
+        return 0
+    fi
+
+    mkdir -p "${state_dir}"
+    cp "${legacy_state_file}" "${state_file}"
 }
 
 validate_profile_files() {


### PR DESCRIPTION
## Summary
- Move the IW612 region state from `/meticulous-user/iw612-region.conf` to `/etc/meticulous/iw612-region.conf` so factory reset no longer deletes the selected Wi-Fi regulatory configuration.
- Migrate existing legacy state from `/meticulous-user` when the new state file is missing.
- Preserve the new region state across RAUC rootfs updates, with fallback migration from the legacy path during the first OTA.

## Validation
- `bash -n scripts/met-iw612-set-region`
- `sh -n rauc-config/rootfs_hooks.sh`
- Ran `met-iw612-set-region` with temporary firmware/state paths to verify new state writes and legacy state migration.
