### PR TITLE
Bound fluent-bit buffering for beta

### DIFF
--- a/config/etc/fluent-bit/fluent-bit.conf
+++ b/config/etc/fluent-bit/fluent-bit.conf
@@ -5,6 +5,9 @@
     Parsers_File    parsers.conf
     # Persist file tracking offsets across restarts
     storage.path    /var/lib/fluent-bit/
+    storage.sync    normal
+    storage.checksum Off
+    storage.backlog.mem_limit 32M
     # Built-in Prometheus-style metrics endpoint for local diagnostics
     HTTP_Server     Off
     HTTP_Listen     0.0.0.0
@@ -20,6 +23,8 @@
     Strip_Underscores On
     Lowercase       On
     DB              /var/lib/fluent-bit/systemd.db
+    Mem_Buf_Limit   32M
+    storage.type    filesystem
 
 # ==============================================================
 # Input: node exporter metrics (metrics pipeline)
@@ -31,6 +36,7 @@
     Tag             metrics.node
     Scrape_Interval 15
     Metrics         cpu,meminfo,diskstats
+    Mem_Buf_Limit   8M
 
 # ==============================================================
 # Filter: enrich logs with device metadata
@@ -62,8 +68,9 @@
     # TLS for transport encryption
     tls             On
     tls.verify      On
-    # Retry forever - edge devices may be offline
-    Retry_Limit     False
+    # Bound offline buffering so telemetry cannot OOM the machine.
+    Retry_Limit     30
+    storage.total_limit_size 256M
     # Shared secret must match server-side Fluentd config
     Shared_Key      meticulous-edge-logs
 
@@ -79,5 +86,7 @@
     Metrics_Uri     /v1/metrics
     Tls             On
     Tls.Verify      On
-    Retry_Limit     False
+    # Metrics are sampled frequently, so drop old retries instead of growing memory.
+    Retry_Limit     5
+    storage.total_limit_size 32M
     Add_Label       host.name ${HOSTNAME}


### PR DESCRIPTION
## Summary
- Backport the nightly Fluent Bit buffering limits to beta.
- Root cause: when the forward log collector is unreachable, `Retry_Limit False` keeps retrying indefinitely and the systemd input stores chunks in memory, which can grow until the machine hits memory pressure or OOM.
- This adds filesystem-backed buffering for systemd logs, caps in-memory buffers, bounds backlog memory, and limits retry/storage growth for log and metrics outputs.

## Sentry signal
Informational comparison from `meticulous-linux` Sentry events over the last 14 days, using `build-version` and unique `hostname` to normalize by machines observed in Sentry. This is directionally useful rather than statistically conclusive: nightly has a much smaller population than beta, so the comparison is sensitive to small sample sizes. Still, the absence of backend/watcher OOMs in the latest nightly sample matches the expected effect of bounding Fluent Bit backlog growth.

```text
2026M1266-beta:
  total crash events: 126
  hostnames con crash events: 40
  OOM events: 10
  hostnames con OOM: 7
  backend OOM: 8 events / 5 machines
  watcher OOM: 1 event / 1 machine
  dial OOM: 1 event / 1 machine

2026M1277-nightly:
  total crash events: 51
  hostnames con crash events: 8
  OOM events: 1
  hostnames con OOM: 1
  backend OOM: 0
  watcher OOM: 0
  dial OOM: 1 event / 1 machine
```

## Validation
- `git diff --cached --check`
- Compared `config/etc/fluent-bit/fluent-bit.conf` against the fixed nightly version from `cfaeec1`.
- Confirmed the PR only changes `config/etc/fluent-bit/fluent-bit.conf`.
- Queried Sentry `meticulous-linux` events by `build-version` and unique `hostname` for the latest beta/nightly builds.