### PR TITLE
Publish smoke validation attributes

### DIFF
--- a/scripts/meticulous-smoke-report
+++ b/scripts/meticulous-smoke-report
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+import argparse
+import configparser
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+HAWKBIT_CONFIG = Path("/etc/hawkbit/config.conf")
+HAWKBIT_CONFIG_GENERATOR = Path("/etc/hawkbit/create_config.sh")
+BACKEND_URL = "http://127.0.0.1:8080/api/v1/smoke-validation"
+DIAL_READY_MARKER = Path("/run/meticulous-dial-ready")
+DIAL_HOME_READY_MARKER = Path("/run/meticulous-dial-home-ready")
+VERSION_FILE = Path("/opt/image-build-version")
+
+
+def now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_text(path, default="unknown"):
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+        return value or default
+    except Exception:
+        return default
+
+
+def bool_string(value):
+    return "true" if value else "false"
+
+
+def run(command, timeout=10):
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except Exception as exc:
+        return subprocess.CompletedProcess(command, 1, "", str(exc))
+
+
+def systemd_active(unit):
+    return run(["systemctl", "is-active", "--quiet", unit]).returncode == 0
+
+
+def read_backend_status(timeout=5):
+    request = urllib.request.Request(BACKEND_URL, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def boot_checks():
+    checks = {
+        "backend_service": systemd_active("meticulous-backend.service"),
+        "dial_service": systemd_active("meticulous-dial.service"),
+        "dial_ready": DIAL_READY_MARKER.exists(),
+        "dial_home_ready": DIAL_HOME_READY_MARKER.exists(),
+        "backend_initialized": False,
+        "esp32_responding": False,
+    }
+    backend_status = {}
+
+    try:
+        backend_status = read_backend_status()
+        checks["backend_initialized"] = backend_status.get("backend_initialized") is True
+        checks["esp32_responding"] = backend_status.get("esp32_responding") is True
+    except Exception as exc:
+        backend_status = {"error": str(exc)}
+
+    return checks, backend_status
+
+
+def wait_for_boot_checks(timeout):
+    deadline = time.monotonic() + timeout
+    checks = {}
+    backend_status = {}
+    while time.monotonic() <= deadline:
+        checks, backend_status = boot_checks()
+        if all(checks.values()):
+            break
+        time.sleep(3)
+    return checks, backend_status
+
+
+def make_boot_attributes(timeout):
+    checks, backend_status = wait_for_boot_checks(timeout)
+    failed = [name for name, passed in checks.items() if not passed]
+
+    return {
+        "boot_smoke_status": "pass" if not failed else "fail",
+        "boot_smoke_at": now(),
+        "boot_smoke_version": read_text(VERSION_FILE),
+        "boot_smoke_backend": bool_string(checks.get("backend_initialized")),
+        "boot_smoke_dial": bool_string(
+            checks.get("dial_service") and checks.get("dial_ready")
+        ),
+        "boot_smoke_dial_home": bool_string(checks.get("dial_home_ready")),
+        "boot_smoke_esp32": bool_string(checks.get("esp32_responding")),
+        "boot_smoke_failed_checks": ",".join(failed),
+        "boot_smoke_machine_status": str(backend_status.get("machine_status", "")),
+        "boot_smoke_firmware_version": str(backend_status.get("firmware_version", "")),
+    }
+
+
+def make_shot_attributes():
+    try:
+        backend_status = read_backend_status()
+    except Exception as exc:
+        backend_status = {"error": str(exc)}
+
+    completed = backend_status.get("post_update_shot_completed") is True
+    return {
+        "post_update_shot_completed": bool_string(completed),
+        "post_update_shot_completed_at": str(
+            backend_status.get("post_update_shot_completed_at") or ""
+        ),
+        "post_update_shot_version": str(
+            backend_status.get("post_update_shot_completed_version")
+            or backend_status.get("image_version")
+            or read_text(VERSION_FILE)
+        ),
+    }
+
+
+def ensure_hawkbit_config():
+    if HAWKBIT_CONFIG.exists():
+        return
+    if HAWKBIT_CONFIG_GENERATOR.exists():
+        run(["bash", str(HAWKBIT_CONFIG_GENERATOR)], timeout=30)
+
+
+def load_hawkbit_config():
+    ensure_hawkbit_config()
+    parser = configparser.ConfigParser()
+    parser.read(HAWKBIT_CONFIG)
+    client = parser["client"]
+
+    scheme = "https" if client.getboolean("ssl", fallback=True) else "http"
+    server = client.get("hawkbit_server")
+    tenant = client.get("tenant_id", fallback="DEFAULT")
+    target = client.get("target_name")
+    ssl_verify = client.getboolean("ssl_verify", fallback=True)
+    auth_token = client.get("auth_token", fallback="").strip()
+    gateway_token = client.get("gateway_token", fallback="").strip()
+
+    if not server or not target:
+        raise RuntimeError("Hawkbit config is missing hawkbit_server or target_name")
+    if not auth_token and not gateway_token:
+        raise RuntimeError("Hawkbit config is missing auth_token/gateway_token")
+
+    token_kind = "TargetToken" if auth_token else "GatewayToken"
+    token = auth_token or gateway_token
+    return scheme, server, tenant, target, ssl_verify, token_kind, token
+
+
+def publish_attributes(attributes):
+    scheme, server, tenant, target, ssl_verify, token_kind, token = load_hawkbit_config()
+    quoted_target = urllib.parse.quote(target, safe="")
+    url = f"{scheme}://{server}/{tenant}/controller/v1/{quoted_target}/configData"
+    data = json.dumps({"mode": "merge", "data": attributes}).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method="PUT",
+        headers={
+            "Authorization": f"{token_kind} {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+
+    context = None
+    if scheme == "https" and not ssl_verify:
+        import ssl
+
+        context = ssl._create_unverified_context()
+
+    with urllib.request.urlopen(request, timeout=30, context=context) as response:
+        response.read()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--boot", action="store_true", help="run boot smoke checks")
+    parser.add_argument(
+        "--shot",
+        action="store_true",
+        help="publish persisted post-update shot state without waiting for boot checks",
+    )
+    parser.add_argument("--timeout", type=int, default=180)
+    args = parser.parse_args()
+
+    attributes = {}
+    if args.boot or not args.shot:
+        attributes.update(make_boot_attributes(args.timeout))
+    attributes.update(make_shot_attributes())
+
+    try:
+        publish_attributes(attributes)
+    except urllib.error.HTTPError as exc:
+        print(
+            f"Failed to publish smoke validation attributes: HTTP {exc.code}",
+            file=sys.stderr,
+        )
+        print(exc.read().decode("utf-8", errors="replace"), file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Failed to publish smoke validation attributes: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(attributes, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/system-services/meticulous-smoke-report.service
+++ b/system-services/meticulous-smoke-report.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Publish Meticulous smoke validation status to Hawkbit
+ConditionHost=meticulous*
+After=network-online.target meticulous-backend.service meticulous-dial.service rauc-hawkbit-updater.service
+Wants=network-online.target
+OnFailure=crash-reporter@.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/meticulous-smoke-report --boot
+TimeoutStartSec=4min
+User=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add a boot-time `meticulous-smoke-report.service` that publishes smoke validation attributes to Hawkbit.
- Add `/usr/local/bin/meticulous-smoke-report` to collect local systemd/backend/dial markers and publish them through the Hawkbit DDI `configData` endpoint.
- Publish boot smoke and post-update shot smoke attributes without blocking on Wi-Fi health checks.

## High-level conditions
- `boot_smoke_backend` passes when the backend service is active and the backend smoke endpoint reports it is initialized.
- `boot_smoke_esp32` passes when the backend smoke endpoint reports an `ESPInfo` response from the ESP32.
- `boot_smoke_dial` passes when `meticulous-dial.service` is active and the dial created `/run/meticulous-dial-ready`.
- `boot_smoke_dial_home` passes only when the dial created `/run/meticulous-dial-home-ready`, meaning it reached the usable profile home screen with profiles loaded.
- `boot_smoke_status` is `pass` only when all required boot checks pass; otherwise `boot_smoke_failed_checks` lists the missing condition.
- `post_update_shot_completed` is published from backend state and indicates the installed image version has completed a full coffee-shot lifecycle after update.

## Related PRs
- Backend smoke state endpoint: https://github.com/MeticulousHome/meticulous-backend/pull/360
- Dial home readiness: https://github.com/MeticulousHome/meticulous-dial/pull/555

## Validation
- `python3 -m py_compile scripts/meticulous-smoke-report`
- `git diff --check`
