### PR TITLE
Wait for Wayland before starting dial

### DIFF
--- a/system-services/meticulous-dial.service
+++ b/system-services/meticulous-dial.service
@@ -2,9 +2,11 @@
 Description=Meticulous Dial App
 After=network.target
 After=weston.service
+Requires=weston.service
 OnFailure=crash-reporter@.service
 
 [Service]
+ExecStartPre=/bin/bash -c 'for i in {1..50}; do test -S /run/user/0/wayland-0 && exit 0; sleep 0.1; done; echo "Timed out waiting for /run/user/0/wayland-0" >&2; exit 1'
 ExecStart=/usr/bin/meticulous-dial
 Restart=on-success
 User=root


### PR DESCRIPTION
## Summary
- Make `meticulous-dial.service` explicitly require `weston.service`.
- Add an `ExecStartPre` gate that waits for `/run/user/0/wayland-0` before launching the dial app.

## High-level behavior
`After=weston.service` only guarantees ordering against the Weston service start request; it does not guarantee the Wayland socket is already present and ready for GTK clients. In the dial-delay logs, the dial app sometimes failed GTK initialization shortly after boot, which is consistent with starting before Weston/Wayland is actually usable.

With this change, the dial process only starts after the Wayland socket exists. If the socket does not appear within 5 seconds, systemd marks the dial service start as failed, preserving the existing failure/restart path instead of launching GTK into an unavailable display.

## Validation
- `git diff --check`

## Notes
- `systemd-analyze verify` is not available in this macOS environment, so hardware/image validation is still needed on target Debian.
- This is intentionally separate from the backend Wi-Fi startup fix so each suspected boot blocker can be reviewed and validated independently.