### PR TITLE
Fix changelog Pages checkout

### DIFF
--- a/.github/workflows/deploy-changelog.yml
+++ b/.github/workflows/deploy-changelog.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- Check out `main` explicitly before generating the GitHub Pages changelog.
- Root cause: the reusable deployment workflow inherited the image build run's starting SHA, so it published a valid but stale Pages artifact after `commit-changelog` pushed a newer commit.
- Ensure newly generated nightly, beta, and stable changelog entries are included in the deployment that follows each image build.

## Validation
- `git diff --check`
- Parsed `.github/workflows/deploy-changelog.yml` successfully with PyYAML.
- Generated the changelog HTML successfully with `generate-changelog-html.py`.