### PR TITLE
Publish the ESP32 device UUID for Hawkbit migration

### DIFF
--- a/config/etc/hawkbit/config.conf.template
+++ b/config/etc/hawkbit/config.conf.template
@@ -28,6 +28,7 @@
   som                       = __SOM__
   installed_version         = __INSTALLED_VERSION__
   backup_version            = __BACKUP_VERSION__
+  next_controller_id        = __NEXT_CONTROLLER_ID__
   memory                    = __MEMORY__
   uboot_active_version      = __UBOOT_ACTIVE_REV__
   uboot_active_slot         = __UBOOT_ACTIVE__

--- a/config/etc/hawkbit/create_config.sh
+++ b/config/etc/hawkbit/create_config.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "${HAWKBIT_DEVICE_IDENTITY_LIB:-/etc/hawkbit/device_identity.sh}"
+
 get_somrev() {
         # Get the raw output
         raw_output=$(i2cget -f -y 0x0 0x52 0x1e)
@@ -155,6 +157,7 @@ fi
 
 installed_version=$(get_installed_sw_version)
 backup_version=$(get_backup_sw_version)
+device_uuid=$(get_or_create_device_uuid) || device_uuid="UNKNOWN"
 
 memory=$(cat /proc/meminfo | grep MemTotal | grep "[0-9]* [a-zA-Z]B" -o)
 som=$(get_somrev)
@@ -188,6 +191,7 @@ sed -i "s/__SOM__/${som}/" /etc/hawkbit/config.conf
 sed -i "s/__MEMORY__/${memory}/" /etc/hawkbit/config.conf
 sed -i "s/__INSTALLED_VERSION__/${installed_version}/" /etc/hawkbit/config.conf
 sed -i "s/__BACKUP_VERSION__/${backup_version}/" /etc/hawkbit/config.conf
+sed -i "s/__NEXT_CONTROLLER_ID__/${device_uuid}/" /etc/hawkbit/config.conf
 
 sed -i "s/__UBOOT_DISK_REV__/${uboot_disk_rev}/" /etc/hawkbit/config.conf
 sed -i "s/__UBOOT_BOOT0_REV__/${uboot_boot0_rev}/" /etc/hawkbit/config.conf

--- a/config/etc/hawkbit/create_config.sh
+++ b/config/etc/hawkbit/create_config.sh
@@ -157,7 +157,7 @@ fi
 
 installed_version=$(get_installed_sw_version)
 backup_version=$(get_backup_sw_version)
-device_uuid=$(get_or_create_device_uuid) || device_uuid="UNKNOWN"
+device_uuid=$(get_cached_device_uuid) || device_uuid="UNKNOWN"
 
 memory=$(cat /proc/meminfo | grep MemTotal | grep "[0-9]* [a-zA-Z]B" -o)
 som=$(get_somrev)

--- a/config/etc/hawkbit/device_identity.sh
+++ b/config/etc/hawkbit/device_identity.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+HAWKBIT_DEVICE_IDENTITY_DIR="${HAWKBIT_DEVICE_IDENTITY_DIR:-/meticulous-user/.device-identity}"
+HAWKBIT_DEVICE_UUID_FILE="${HAWKBIT_DEVICE_UUID_FILE:-${HAWKBIT_DEVICE_IDENTITY_DIR}/device-uuid}"
+HAWKBIT_UUID_SOURCE="${HAWKBIT_UUID_SOURCE:-/proc/sys/kernel/random/uuid}"
+
+is_valid_uuid_v4() {
+  local uuid="$1"
+
+  [[ "$uuid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
+}
+
+generate_uuid_v4() {
+  local uuid
+
+  if [ ! -r "$HAWKBIT_UUID_SOURCE" ]; then
+    echo "Cannot read UUID source ${HAWKBIT_UUID_SOURCE}" >&2
+    return 1
+  fi
+
+  IFS= read -r uuid < "$HAWKBIT_UUID_SOURCE"
+  if ! is_valid_uuid_v4 "$uuid"; then
+    echo "UUID source returned an invalid UUIDv4" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$uuid"
+}
+
+get_or_create_device_uuid() {
+  local current_uuid=""
+  local generated_uuid
+  local temporary_file
+
+  if [ -r "$HAWKBIT_DEVICE_UUID_FILE" ]; then
+    IFS= read -r current_uuid < "$HAWKBIT_DEVICE_UUID_FILE"
+    if is_valid_uuid_v4 "$current_uuid"; then
+      printf '%s\n' "$current_uuid"
+      return 0
+    fi
+
+    echo "Replacing invalid Hawkbit device UUID at ${HAWKBIT_DEVICE_UUID_FILE}" >&2
+  fi
+
+  generated_uuid=$(generate_uuid_v4) || return 1
+
+  # The hidden directory is on the shared user partition so it survives OTA,
+  # slot rollback, and the current factory-reset cleanup of /meticulous-user/*.
+  if ! mkdir -p "$HAWKBIT_DEVICE_IDENTITY_DIR"; then
+    echo "Cannot create Hawkbit device identity directory" >&2
+    return 1
+  fi
+  chmod 700 "$HAWKBIT_DEVICE_IDENTITY_DIR" || return 1
+
+  temporary_file=$(mktemp "${HAWKBIT_DEVICE_UUID_FILE}.tmp.XXXXXX") || return 1
+  if ! printf '%s\n' "$generated_uuid" > "$temporary_file"; then
+    rm -f "$temporary_file"
+    return 1
+  fi
+  if ! chmod 600 "$temporary_file"; then
+    rm -f "$temporary_file"
+    return 1
+  fi
+  if ! mv -f "$temporary_file" "$HAWKBIT_DEVICE_UUID_FILE"; then
+    rm -f "$temporary_file"
+    return 1
+  fi
+
+  printf '%s\n' "$generated_uuid"
+}

--- a/config/etc/hawkbit/device_identity.sh
+++ b/config/etc/hawkbit/device_identity.sh
@@ -2,7 +2,6 @@
 
 HAWKBIT_DEVICE_IDENTITY_DIR="${HAWKBIT_DEVICE_IDENTITY_DIR:-/meticulous-user/.device-identity}"
 HAWKBIT_DEVICE_UUID_FILE="${HAWKBIT_DEVICE_UUID_FILE:-${HAWKBIT_DEVICE_IDENTITY_DIR}/device-uuid}"
-HAWKBIT_UUID_SOURCE="${HAWKBIT_UUID_SOURCE:-/proc/sys/kernel/random/uuid}"
 
 is_valid_uuid_v4() {
   local uuid="$1"
@@ -10,61 +9,19 @@ is_valid_uuid_v4() {
   [[ "$uuid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
 }
 
-generate_uuid_v4() {
-  local uuid
+get_cached_device_uuid() {
+  local cached_uuid=""
 
-  if [ ! -r "$HAWKBIT_UUID_SOURCE" ]; then
-    echo "Cannot read UUID source ${HAWKBIT_UUID_SOURCE}" >&2
+  if [ ! -r "$HAWKBIT_DEVICE_UUID_FILE" ]; then
+    echo "ESP32 device UUID cache is not available" >&2
     return 1
   fi
 
-  IFS= read -r uuid < "$HAWKBIT_UUID_SOURCE"
-  if ! is_valid_uuid_v4 "$uuid"; then
-    echo "UUID source returned an invalid UUIDv4" >&2
+  IFS= read -r cached_uuid < "$HAWKBIT_DEVICE_UUID_FILE"
+  if ! is_valid_uuid_v4 "$cached_uuid"; then
+    echo "ESP32 device UUID cache is invalid" >&2
     return 1
   fi
 
-  printf '%s\n' "$uuid"
-}
-
-get_or_create_device_uuid() {
-  local current_uuid=""
-  local generated_uuid
-  local temporary_file
-
-  if [ -r "$HAWKBIT_DEVICE_UUID_FILE" ]; then
-    IFS= read -r current_uuid < "$HAWKBIT_DEVICE_UUID_FILE"
-    if is_valid_uuid_v4 "$current_uuid"; then
-      printf '%s\n' "$current_uuid"
-      return 0
-    fi
-
-    echo "Replacing invalid Hawkbit device UUID at ${HAWKBIT_DEVICE_UUID_FILE}" >&2
-  fi
-
-  generated_uuid=$(generate_uuid_v4) || return 1
-
-  # The hidden directory is on the shared user partition so it survives OTA,
-  # slot rollback, and the current factory-reset cleanup of /meticulous-user/*.
-  if ! mkdir -p "$HAWKBIT_DEVICE_IDENTITY_DIR"; then
-    echo "Cannot create Hawkbit device identity directory" >&2
-    return 1
-  fi
-  chmod 700 "$HAWKBIT_DEVICE_IDENTITY_DIR" || return 1
-
-  temporary_file=$(mktemp "${HAWKBIT_DEVICE_UUID_FILE}.tmp.XXXXXX") || return 1
-  if ! printf '%s\n' "$generated_uuid" > "$temporary_file"; then
-    rm -f "$temporary_file"
-    return 1
-  fi
-  if ! chmod 600 "$temporary_file"; then
-    rm -f "$temporary_file"
-    return 1
-  fi
-  if ! mv -f "$temporary_file" "$HAWKBIT_DEVICE_UUID_FILE"; then
-    rm -f "$temporary_file"
-    return 1
-  fi
-
-  printf '%s\n' "$generated_uuid"
+  printf '%s\n' "$cached_uuid"
 }

--- a/docs/hawkbit-device-identity.md
+++ b/docs/hawkbit-device-identity.md
@@ -1,0 +1,38 @@
+# Hawkbit device identity
+
+The Hawkbit updater continues to use the existing hostname-based
+`target_name`. During the first migration phase, each machine also publishes a
+random UUIDv4 as the `next_controller_id` device attribute.
+
+The UUID is stored at:
+
+```text
+/meticulous-user/.device-identity/device-uuid
+```
+
+The hidden directory is on the shared user partition. It therefore survives
+RAUC slot updates and rollbacks. The current backend factory reset removes
+`/meticulous-user/*`; shell globbing does not include hidden entries, so the
+identity also survives that reset.
+
+The generated directory and file use modes `0700` and `0600`. The UUID is an
+opaque identifier, not a credential.
+
+If the file is missing, the updater generates a UUIDv4 from
+`/proc/sys/kernel/random/uuid` and writes it atomically. If the stored value is
+not a lowercase RFC 4122 UUIDv4, it is replaced while the UUID is still only a
+migration candidate. A source or filesystem failure leaves
+`next_controller_id` as `UNKNOWN` without changing the active Hawkbit target.
+
+Before switching `target_name`, fleet validation must confirm:
+
+- every online target reports a valid UUIDv4;
+- no two targets report the same UUID;
+- the UUID remains unchanged across updater restarts, OTA rollback, and factory
+  reset;
+- no target reports `UNKNOWN`.
+
+The updater sends device attributes only when Hawkbit includes the
+`configData` link in its DDI response. After deploying this image, request
+attributes for the existing targets by setting `requestAttributes` to `true`
+through the Hawkbit Management API before auditing `next_controller_id`.

--- a/docs/hawkbit-device-identity.md
+++ b/docs/hawkbit-device-identity.md
@@ -1,8 +1,8 @@
 # Hawkbit device identity
 
 The Hawkbit updater continues to use the existing hostname-based
-`target_name`. During the first migration phase, each machine also publishes a
-random UUIDv4 as the `next_controller_id` device attribute.
+`target_name`. During the first migration phase, each machine also publishes
+the ESP32-owned UUIDv4 as the `next_controller_id` device attribute.
 
 The UUID is stored at:
 
@@ -10,19 +10,21 @@ The UUID is stored at:
 /meticulous-user/.device-identity/device-uuid
 ```
 
-The hidden directory is on the shared user partition. It therefore survives
-RAUC slot updates and rollbacks. The current backend factory reset removes
-`/meticulous-user/*`; shell globbing does not include hidden entries, so the
-identity also survives that reset.
+The ESP32 NVS value is the source of truth. When the backend receives ESPInfo,
+it validates the UUID and atomically updates this VAR-SOM cache whenever the
+ESP32 value differs. The backend then restarts the Hawkbit updater so its
+generated configuration uses the current cache.
 
-The generated directory and file use modes `0700` and `0600`. The UUID is an
-opaque identifier, not a credential.
+The hidden cache directory is on the shared user partition. It therefore
+survives RAUC slot updates and rollbacks. The current backend factory reset
+removes `/meticulous-user/*`; shell globbing does not include hidden entries,
+so the cache also survives that reset. The directory and file use modes `0700`
+and `0600`. The UUID is an opaque identifier, not a credential.
 
-If the file is missing, the updater generates a UUIDv4 from
-`/proc/sys/kernel/random/uuid` and writes it atomically. If the stored value is
-not a lowercase RFC 4122 UUIDv4, it is replaced while the UUID is still only a
-migration candidate. A source or filesystem failure leaves
-`next_controller_id` as `UNKNOWN` without changing the active Hawkbit target.
+The updater never generates or repairs device identity. If the cache is
+missing or invalid, it reports `next_controller_id` as `UNKNOWN` without
+changing the active Hawkbit target. The backend repairs the cache only from a
+valid ESP32 value.
 
 Before switching `target_name`, fleet validation must confirm:
 
@@ -31,6 +33,13 @@ Before switching `target_name`, fleet validation must confirm:
 - the UUID remains unchanged across updater restarts, OTA rollback, and factory
   reset;
 - no target reports `UNKNOWN`.
+
+This change depends on coordinated firmware and backend support:
+
+- EspressoFirmware generates and stores the UUIDv4 in ESP32 NVS when an info
+  request finds no valid value.
+- meticulous-backend parses the UUID from ESPInfo and synchronizes the
+  VAR-SOM cache with the ESP32 value.
 
 The updater sends device attributes only when Hawkbit includes the
 `configData` link in its DDI response. After deploying this image, request

--- a/docs/hawkbit-device-identity.md
+++ b/docs/hawkbit-device-identity.md
@@ -10,10 +10,16 @@ The UUID is stored at:
 /meticulous-user/.device-identity/device-uuid
 ```
 
-The ESP32 NVS value is the source of truth. When the backend receives ESPInfo,
-it validates the UUID and atomically updates this VAR-SOM cache whenever the
-ESP32 value differs. The backend then restarts the Hawkbit updater so its
-generated configuration uses the current cache.
+The VAR-SOM generates the initial UUIDv4 using the Linux OS entropy source only
+when compatible firmware reports that the ESP32 has no valid UUID. It sends the
+candidate through a dedicated write-once UART command. The ESP32 validates and
+persists the value in NVS, then reports it back through ESPInfo.
+
+After that assignment, the ESP32 NVS value is the source of truth. The backend
+updates this VAR-SOM cache only from a valid UUID confirmed through ESPInfo. If
+the confirmed ESP32 value differs, it atomically overwrites the cache and
+restarts the Hawkbit updater so its generated configuration uses the current
+value.
 
 The hidden cache directory is on the shared user partition. It therefore
 survives RAUC slot updates and rollbacks. The current backend factory reset
@@ -23,8 +29,13 @@ and `0600`. The UUID is an opaque identifier, not a credential.
 
 The updater never generates or repairs device identity. If the cache is
 missing or invalid, it reports `next_controller_id` as `UNKNOWN` without
-changing the active Hawkbit target. The backend repairs the cache only from a
-valid ESP32 value.
+changing the active Hawkbit target.
+
+The backend never copies a previously cached VAR-SOM UUID into an empty or
+corrupt ESP32. That state may indicate that the ESP32 was replaced. Instead, it
+generates a new candidate, assigns it write-once, waits for the ESP32 to confirm
+it, and then replaces the VAR-SOM cache. A valid UUID already stored on the
+ESP32 always wins.
 
 Before switching `target_name`, fleet validation must confirm:
 
@@ -36,10 +47,10 @@ Before switching `target_name`, fleet validation must confirm:
 
 This change depends on coordinated firmware and backend support:
 
-- EspressoFirmware generates and stores the UUIDv4 in ESP32 NVS when an info
-  request finds no valid value.
-- meticulous-backend parses the UUID from ESPInfo and synchronizes the
-  VAR-SOM cache with the ESP32 value.
+- EspressoFirmware exposes UUID protocol support in ESPInfo and accepts a
+  dedicated write-once assignment only while no valid UUID exists in NVS.
+- meticulous-backend generates the initial UUIDv4, sends the assignment, waits
+  for ESPInfo confirmation, and then synchronizes the VAR-SOM cache.
 
 The updater sends device attributes only when Hawkbit includes the
 `configData` link in its DDI response. After deploying this image, request

--- a/tests/test_hawkbit_device_identity.sh
+++ b/tests/test_hawkbit_device_identity.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+export HAWKBIT_DEVICE_IDENTITY_DIR="${test_root}/meticulous-user/.device-identity"
+export HAWKBIT_DEVICE_UUID_FILE="${HAWKBIT_DEVICE_IDENTITY_DIR}/device-uuid"
+export HAWKBIT_UUID_SOURCE="${test_root}/uuid-source"
+
+source "${repo_root}/config/etc/hawkbit/device_identity.sh"
+
+first_uuid="123e4567-e89b-42d3-a456-426614174000"
+second_uuid="987e6543-e21b-45d3-b654-426614174999"
+printf '%s\n' "$first_uuid" > "$HAWKBIT_UUID_SOURCE"
+
+generated_uuid=$(get_or_create_device_uuid)
+test "$generated_uuid" = "$first_uuid"
+is_valid_uuid_v4 "$generated_uuid"
+test "$(stat -c '%a' "$HAWKBIT_DEVICE_IDENTITY_DIR")" = "700"
+test "$(stat -c '%a' "$HAWKBIT_DEVICE_UUID_FILE")" = "600"
+
+printf '%s\n' "$second_uuid" > "$HAWKBIT_UUID_SOURCE"
+reused_uuid=$(get_or_create_device_uuid)
+test "$reused_uuid" = "$first_uuid"
+
+printf '%s\n' "invalid" > "$HAWKBIT_DEVICE_UUID_FILE"
+replacement_uuid=$(get_or_create_device_uuid)
+test "$replacement_uuid" = "$second_uuid"
+
+mkdir -p "${test_root}/meticulous-user/config"
+printf '%s\n' "user data" > "${test_root}/meticulous-user/config/settings"
+rm -rf "${test_root}/meticulous-user/"*
+
+test ! -e "${test_root}/meticulous-user/config"
+test -f "$HAWKBIT_DEVICE_UUID_FILE"
+test "$(get_or_create_device_uuid)" = "$second_uuid"
+
+printf '%s\n' "not-a-uuid" > "$HAWKBIT_UUID_SOURCE"
+rm -f "$HAWKBIT_DEVICE_UUID_FILE"
+if get_or_create_device_uuid; then
+  echo "Expected invalid UUID source to fail" >&2
+  exit 1
+fi
+
+echo "Hawkbit device identity tests passed"

--- a/tests/test_hawkbit_device_identity.sh
+++ b/tests/test_hawkbit_device_identity.sh
@@ -8,27 +8,31 @@ trap 'rm -rf "$test_root"' EXIT
 
 export HAWKBIT_DEVICE_IDENTITY_DIR="${test_root}/meticulous-user/.device-identity"
 export HAWKBIT_DEVICE_UUID_FILE="${HAWKBIT_DEVICE_IDENTITY_DIR}/device-uuid"
-export HAWKBIT_UUID_SOURCE="${test_root}/uuid-source"
 
 source "${repo_root}/config/etc/hawkbit/device_identity.sh"
 
 first_uuid="123e4567-e89b-42d3-a456-426614174000"
 second_uuid="987e6543-e21b-45d3-b654-426614174999"
-printf '%s\n' "$first_uuid" > "$HAWKBIT_UUID_SOURCE"
 
-generated_uuid=$(get_or_create_device_uuid)
-test "$generated_uuid" = "$first_uuid"
-is_valid_uuid_v4 "$generated_uuid"
-test "$(stat -c '%a' "$HAWKBIT_DEVICE_IDENTITY_DIR")" = "700"
-test "$(stat -c '%a' "$HAWKBIT_DEVICE_UUID_FILE")" = "600"
+if get_cached_device_uuid; then
+  echo "Expected a missing ESP32 device UUID cache to fail" >&2
+  exit 1
+fi
 
-printf '%s\n' "$second_uuid" > "$HAWKBIT_UUID_SOURCE"
-reused_uuid=$(get_or_create_device_uuid)
-test "$reused_uuid" = "$first_uuid"
+mkdir -p "$HAWKBIT_DEVICE_IDENTITY_DIR"
+printf '%s\n' "$first_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
+test "$(get_cached_device_uuid)" = "$first_uuid"
 
 printf '%s\n' "invalid" > "$HAWKBIT_DEVICE_UUID_FILE"
-replacement_uuid=$(get_or_create_device_uuid)
-test "$replacement_uuid" = "$second_uuid"
+if get_cached_device_uuid; then
+  echo "Expected an invalid ESP32 device UUID cache to fail" >&2
+  exit 1
+fi
+
+# The backend treats the ESP32 as the source of truth and replaces a different
+# VAR-SOM cache value with the UUID reported by the ESP32.
+printf '%s\n' "$second_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
+test "$(get_cached_device_uuid)" = "$second_uuid"
 
 mkdir -p "${test_root}/meticulous-user/config"
 printf '%s\n' "user data" > "${test_root}/meticulous-user/config/settings"
@@ -36,13 +40,6 @@ rm -rf "${test_root}/meticulous-user/"*
 
 test ! -e "${test_root}/meticulous-user/config"
 test -f "$HAWKBIT_DEVICE_UUID_FILE"
-test "$(get_or_create_device_uuid)" = "$second_uuid"
-
-printf '%s\n' "not-a-uuid" > "$HAWKBIT_UUID_SOURCE"
-rm -f "$HAWKBIT_DEVICE_UUID_FILE"
-if get_or_create_device_uuid; then
-  echo "Expected invalid UUID source to fail" >&2
-  exit 1
-fi
+test "$(get_cached_device_uuid)" = "$second_uuid"
 
 echo "Hawkbit device identity tests passed"


### PR DESCRIPTION
## Summary

- keep the current hostname-based Hawkbit `target_name` unchanged during the observational migration
- publish the ESP32-confirmed UUID as the `next_controller_id` device attribute
- make the updater read the hidden VAR-SOM cache without generating or repairing identity locally
- report `UNKNOWN` when the cache is missing or invalid, so rollout sanity checks can detect unsynchronized machines
- document the enrollment and persistence contract

The VAR-SOM generates a UUIDv4 from the Linux OS entropy source only when compatible firmware reports that the ESP32 has no valid UUID. The ESP32 accepts it write-once and reports it back. Only that confirmed value may update `/meticulous-user/.device-identity/device-uuid` and restart the updater.

A valid ESP32 UUID always wins. An empty or corrupt ESP32 receives a newly generated UUID; the backend never copies an old VAR-SOM cache value back into it.

## Related PRs

- MeticulousHome/EspressoFirmware#490 — accept and persist the write-once UUID assignment
- MeticulousHome/meticulous-backend#372 — enroll the ESP32 and cache only its confirmed value

## Validation

- `bash tests/test_hawkbit_device_identity.sh`
- `bash -n config/etc/hawkbit/device_identity.sh config/etc/hawkbit/create_config.sh tests/test_hawkbit_device_identity.sh`
- `git diff --check`

The tests cover missing and invalid caches, a valid cached UUID, replacement with a different ESP32 UUID, and survival of the current factory-reset glob.