### PR TITLE
chore: preserve redaction key for hmac log pseudonymization

### DIFF
--- a/rauc-config/rootfs_hooks.sh
+++ b/rauc-config/rootfs_hooks.sh
@@ -26,9 +26,18 @@ case "$1" in
                         mkdir -p "$RAUC_SLOT_MOUNT_POINT/root/.ssh"
                         cp -rv /root/.ssh/authorized_keys "$RAUC_SLOT_MOUNT_POINT/root/.ssh/"
                 fi
+
+                #Keep the log redactions keys stable
+                if [ -e /root/.redaction_key ]; then
+                        echo "Copying log redaction key to installed rootfs"
+                        cp -rv /root/.redaction_key     "$RAUC_SLOT_MOUNT_POINT/root/"
+                else
+                        echo "no .redaction_key available at /root/.redaction_key"
+                fi
+
                 fw_setenv BOOT_A_LEFT 3
                 fw_setenv BOOT_B_LEFT 3
-                shutdown -r 03:00
+                shutdown -r 03:00 #! this should be a soft signal sent to the backend, we dont want to restart the machine mid-shot
                 ;;
         *)
                 exit 1


### PR DESCRIPTION
Preserves the `.redaction_key` used when redacting logs in between SW updates

The `redaction key` is used to redact, using HMAC SHA256 possible sensitive information from the system logs but in a way that they can still be traceable withing the logs themselves so we can now if  a value changes without knowing the real value

##

Do we need this? if the key changes in between FW updates, the main point of conflict are logs around the FW change with the same redacted value being redacted in 2 different ways