### PR TITLE
Keep image channel selection explicit

### DIFF
--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -20,32 +20,59 @@ permissions:
   id-token: write
   pages: write
 
-run-name: "Build ${{ github.ref_name }} image"
+run-name: "Build ${{ github.event_name == 'schedule' && 'nightly' || github.ref_name }} image"
 
 jobs:
+  resolve-build-context:
+    name: Resolve build context
+    runs-on: ubuntu-24.04
+    outputs:
+      image: ${{ steps.resolve.outputs.image }}
+      machine_ref: ${{ steps.resolve.outputs.machine_ref }}
+    steps:
+      - name: Select image and machine configuration
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            image="nightly"
+            machine_ref="nightly"
+          else
+            image="$REF_NAME"
+            machine_ref="$REF_NAME"
+          fi
+
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "machine_ref=$machine_ref" >> "$GITHUB_OUTPUT"
+
   build-image:
     name: Build via selected branch
+    needs: resolve-build-context
     uses: ./.github/workflows/build-image-channel.yml
     with:
-      image: ${{ github.ref_name }}
-      machine-ref: ${{ github.ref_name }}
+      image: ${{ needs.resolve-build-context.outputs.image }}
+      machine-ref: ${{ needs.resolve-build-context.outputs.machine_ref }}
       upload_emmc_to_hawkbit: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_emmc_to_hawkbit }}
       no-cache: ${{ github.event_name == 'workflow_dispatch' && inputs.no-cache || false }}
     secrets: inherit
 
   tag-controlled-repos:
     name: Tag controlled component repos
-    needs: build-image
+    needs:
+      - resolve-build-context
+      - build-image
     runs-on: ubuntu-24.04
     env:
-      IMAGE: ${{ github.ref_name }}
+      IMAGE: ${{ needs.resolve-build-context.outputs.image }}
       BUILD_VERSION_NUMBER: ${{ needs.build-image.outputs.build_version_number }}
-      BUILD_TAG: ${{ github.ref_name }}/${{ needs.build-image.outputs.build_version_number }}
+      BUILD_TAG: ${{ needs.resolve-build-context.outputs.image }}/${{ needs.build-image.outputs.build_version_number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref_name }}
+          ref: ${{ needs.resolve-build-context.outputs.machine_ref }}
 
       - name: Set up Git authentication
         run: |
@@ -60,7 +87,9 @@ jobs:
 
   commit-changelog:
     name: Commit changelog to main
-    needs: build-image
+    needs:
+      - resolve-build-context
+      - build-image
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_emmc_to_hawkbit }}
     runs-on: ubuntu-24.04
     steps:
@@ -84,12 +113,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git add "images/changes/${{ github.ref_name }}/"
+          git add "images/changes/${{ needs.resolve-build-context.outputs.image }}/"
 
           if git diff --cached --quiet; then
             echo "No changelog changes to commit."
           else
-            git commit -m "changelog: ${{ github.ref_name }} build #${{ github.run_number }}"
+            git commit -m "changelog: ${{ needs.resolve-build-context.outputs.image }} build #${{ github.run_number }}"
             git push origin HEAD:main
           fi
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ which can be transfered to the machines emmc
 ## TLDR
 
 ```bash
-update-sources.sh --all
+update-sources.sh --all --image stable
 build-components.sh --all
 sudo make-rootfs.sh --all
 sudo make-sdcard.sh --image
@@ -23,7 +23,7 @@ installed
 Before running any scripts, ensure you have installed all necessary dependencies and configured the config.sh file for your environment.
 
 ```bash
-update-sources.sh --all
+update-sources.sh --all --image stable
 ```
 
 The update-sources.sh script manages the updating and checking out of various software components from their respective repositories.
@@ -33,7 +33,15 @@ Usage
 update-sources.sh [OPTIONS]
 ```
 
-By default, running the script should be done with the `--all` flag which will update all components.
+For a full initial checkout, use `--all` together with an explicit image channel:
+
+```bash
+update-sources.sh --all --image stable
+```
+
+Component checkouts require `--image` so that a `stable` machine checkout cannot
+silently fetch `nightly` component branches. Use `nightly`, `beta`, `stable`, or
+another image that has a matching `images/<image>.versions.sh` file.
 You can also update specific components using the following options:
 
 - `--install_ubuntu_dependencies`: Installs required dependencies on Ubuntu.

--- a/deb-builder.Dockerfile
+++ b/deb-builder.Dockerfile
@@ -34,7 +34,7 @@ RUN apt update
 RUN apt build-dep -y rauc
 
 COPY ./config.sh ./update-sources.sh ./
-RUN ./update-sources.sh --rauc --psplash
+RUN ./update-sources.sh --rauc --psplash --image nightly
 
 RUN DEBIAN_FRONTEND=noninteractive mk-build-deps -r -i components/rauc/rauc/debian/control \
     -t 'apt-get -y -o Debug::pkgProblemResolver=yes --no-install-recommends'

--- a/docs/meticulous-machine quick-start.md
+++ b/docs/meticulous-machine quick-start.md
@@ -1,10 +1,10 @@
 # Future Codex Sessions: Image Build Workflows
 
-This repo builds Meticulous machine images with GitHub Actions. Image builds now use the workflow branch as the selected image/config channel:
+This repo builds Meticulous machine images with GitHub Actions. Image builds resolve an explicit image/config channel:
 
-- `github.ref_name`: selected branch and image name for `.github/workflows/build-nightly-image.yml`.
-- `image`: internal reusable-workflow input; passed as `github.ref_name`.
-- `machine-ref`: internal reusable-workflow input that selects this repo branch for machine config, scripts, services, RAUC config, and workflow implementation; passed as `github.ref_name`.
+- Scheduled builds always resolve `image=nightly` and `machine-ref=nightly`, regardless of the repository default branch.
+- Manual builds resolve both values from `github.ref_name`, which is the branch selected in the workflow dispatch UI.
+- `machine-ref` selects this repo branch for machine config, scripts, services, and RAUC config.
 
 ## Branch Model
 
@@ -13,15 +13,15 @@ This repo builds Meticulous machine images with GitHub Actions. Image builds now
 - `main` remains the central changelog and GitHub Pages branch, but it is no longer the manual image launcher.
 - Manual image builds are dispatched from the branch to build. The branch name must be the image name.
 - Custom images require their own branch with the same name as the image and a matching `images/<image>.versions.sh`.
-- Scheduled builds assume the repository default branch is `nightly`, because GitHub Actions schedules run from the default branch.
+- Scheduled builds run from the repository default branch but explicitly build the `nightly` image from the `nightly` machine config branch.
 - Manual builds can set only `no-cache` and `upload_emmc_to_hawkbit`.
 
 ## Workflow Roles
 
 - `.github/workflows/build-nightly-image.yml` is the user-facing image build workflow on each build branch.
-- `.github/workflows/build-nightly-image.yml` passes `github.ref_name` directly to `.github/workflows/build-image-channel.yml` through a local reusable workflow call.
+- `.github/workflows/build-nightly-image.yml` resolves the scheduled or manually selected build context and passes it to `.github/workflows/build-image-channel.yml` through a local reusable workflow call.
 - `.github/workflows/build-image-channel.yml` contains the real image build and accepts `image`, `machine-ref`, `no-cache`, and `upload_emmc_to_hawkbit`.
-- `.github/workflows/build-all-components.yml` calls `.github/workflows/build-component.yml` by local reusable workflow path so the channel branch supplies the component workflow implementation.
+- Local reusable workflow calls use the workflow revision selected by GitHub Actions, while repository checkouts use the resolved `machine-ref`.
 - All checkouts of this repository inside the image build path must use `machine-ref`. Private repo checkouts, such as `rauc-secrets`, are separate and should not use `machine-ref`.
 - Component builds receive `machine-ref` through `build-all-components.yml` and `build-component.yml`; `build-component.yml` falls back to `github.ref_name` only for direct/manual component runs.
 

--- a/update-sources.sh
+++ b/update-sources.sh
@@ -242,12 +242,12 @@ function show_help() {
 Usage: ${0##*/} [OPTIONS]
 Run various functions to install dependencies and checkout or update components.
 
-By default --all functions should be used to get a full initial checkout.
+Use --all with --image to get a full initial checkout for a specific channel.
 Specific components can be fetched and updated by passing their names as options.
 
 Available options:
     --all                           Checkout / Update All repositories except for the firmware
-    --image [IMAGE]                 Checkout a specific image version / pinning
+    --image [IMAGE]                 Required channel/version set for component checkouts
 
     --install_ubuntu_dependencies   Install dependencies for Ubuntu
 
@@ -336,6 +336,24 @@ while [[ $# -gt 0 ]]; do
     shift # Shift past the argument
 done
 
+source_checkout_selected=$all_selected
+if [[ $firmware_selected -eq 1 || $mobile_selected -eq 1 || $plotter_ui_selected -eq 1 ]]; then
+    source_checkout_selected=1
+fi
+
+for selected in "${steps[@]}"; do
+    if [[ $selected -eq 1 ]]; then
+        source_checkout_selected=1
+        break
+    fi
+done
+
+if [[ $source_checkout_selected -eq 1 && -z "${IMAGE_NAME:-}" ]]; then
+    echo "Error: --image NAME is required when checking out component sources."
+    echo "Use --image nightly, --image beta, --image stable, or another configured image."
+    exit 1
+fi
+
 if [[ ${IMAGE_NAME} && ${IMAGE_NAME} != "nightly" ]]; then
     VERSIONS_FILE="images/${IMAGE_NAME}.versions.sh"
     if [[ -f "$VERSIONS_FILE" ]]; then
@@ -347,8 +365,6 @@ if [[ ${IMAGE_NAME} && ${IMAGE_NAME} != "nightly" ]]; then
     fi
 elif [[ ${IMAGE_NAME} == "nightly" ]]; then
     echo "Nightly image was requested, always using the defaults in config.sh"
-else
-    echo "No image name provided, using default versions."
 fi
 
 if [ ${install_ubuntu_dependencies_selected} -eq 1 ]; then


### PR DESCRIPTION
## Summary
- Keep scheduled machine builds pinned to the `nightly` image and machine config even after the repository default branch changes.
- Reuse the resolved image for component checkout, build tags, and changelog publication.
- Require `--image` for component source checkouts so a `stable` checkout cannot silently fetch `nightly` components.
- Preserve dependency-only setup and the deb builder's existing nightly source behavior.

The scheduled workflow previously derived its image directly from `github.ref_name`, while `update-sources.sh` silently fell back to the nightly defaults in `config.sh`.

## Validation
- `actionlint .github/workflows/build-nightly-image.yml`
- Parsed the updated workflow with PyYAML.
- Bash 5.2 syntax check for `update-sources.sh`.
- Verified a component checkout without `--image` exits with the expected error.
- `git diff --check`

A full machine image build was not run.