### PR TITLE
Use image build versions for Hawkbit distributions

### DIFF
--- a/.github/workflows/build-image-channel.yml
+++ b/.github/workflows/build-image-channel.yml
@@ -268,8 +268,12 @@ jobs:
 
   build-bundle:
     name: Build RAUC bundle
-    needs: build-root
+    needs:
+      - build-root
+      - generate-version-info
     runs-on: ubuntu-24.04
+    env:
+      BUILD_VERSION_NUMBER: ${{ needs.generate-version-info.outputs.build_version_number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -322,7 +326,7 @@ jobs:
           if-no-files-found: error
 
       - name: Build Bundles
-        run: ./make-ota.sh --variant "${{ inputs.image }}" --cert components/rauc-secrets/keys/beta.rsa4096.cert.pem --key components/rauc-secrets/keys/beta.rsa4096.key.pem
+        run: ./make-ota.sh --variant "${{ inputs.image }}" --version "$BUILD_VERSION_NUMBER" --cert components/rauc-secrets/keys/beta.rsa4096.cert.pem --key components/rauc-secrets/keys/beta.rsa4096.key.pem
 
       - name: Upload EMMC bundle
         uses: actions/upload-artifact@v4
@@ -333,7 +337,9 @@ jobs:
 
   deploy-emmc-bundle:
     name: Upload EMMC image to hawkbit
-    needs: build-bundle
+    needs:
+      - build-bundle
+      - generate-version-info
     if: ${{ inputs.upload_emmc_to_hawkbit }}
     runs-on: ubuntu-24.04
     steps:
@@ -368,7 +374,7 @@ jobs:
             ${{ secrets.HAWKBIT_PASSWORD }} \
             "${{ inputs.image }} EMMC" \
             "${{ inputs.image }} Rootfs EMMC" \
-            "$(date -u +'%Y-%m-%dT%H_%M_%S%z')" \
+            "${{ needs.generate-version-info.outputs.build_version_number }}" \
             "${{ inputs.image }}" \
             "emmc"
 

--- a/.github/workflows/upload-bundle.yml
+++ b/.github/workflows/upload-bundle.yml
@@ -45,6 +45,21 @@ jobs:
         name: emmc-bundle
         github-token: ${{ secrets.GH_TOKEN }}
         path: .
+
+    - name: Read bundle version
+      run: |
+        bundles=( *_emmc_*.raucb )
+        if [[ ${#bundles[@]} -ne 1 || ! -f "${bundles[0]}" ]]; then
+          echo "::error::Expected exactly one EMMC bundle"
+          exit 1
+        fi
+        bundle_version="${bundles[0]#*_emmc_nightly_}"
+        bundle_version="${bundle_version%.raucb}"
+        if [[ ! "$bundle_version" =~ ^[0-9]{4}M[0-9]+-nightly$ ]]; then
+          echo "::error::Unexpected nightly bundle version: $bundle_version"
+          exit 1
+        fi
+        echo "BUNDLE_VERSION=$bundle_version" >> "$GITHUB_ENV"
     
     - name: Upload sdcard bundle
       run: |
@@ -56,7 +71,7 @@ jobs:
           ${{ secrets.HAWKBIT_PASSWORD }} \
           "Nightly SDCard" \
           "Rootfs SDCard" \
-          "$(date -u +'%Y-%m-%dT%H_%M_%S%z')" \
+          "$BUNDLE_VERSION" \
           "nightly" \
           "sdcard"
 
@@ -70,6 +85,6 @@ jobs:
           ${{ secrets.HAWKBIT_PASSWORD }} \
           "Nightly EMMC" \
           "Rootfs EMMC" \
-          "$(date -u +'%Y-%m-%dT%H_%M_%S%z')" \
+          "$BUNDLE_VERSION" \
           "nightly" \
           "emmc"

--- a/make-ota.sh
+++ b/make-ota.sh
@@ -5,6 +5,7 @@ source config.sh
 set -eo pipefail
 
 variant=""
+version=""
 
 # Check if $ROOTFS_PATH exists as a file
 if [[ ! -f $METIUCULOUS_ROOTFS ]]; then
@@ -27,6 +28,10 @@ while [[ $# -gt 0 ]]; do
     --key)
         shift
         key="$1"
+        ;;
+    --version)
+        shift
+        version="$1"
         ;;
     *)
         echo "Invalid argument: $key"

--- a/misc/hawkbit-upload.py
+++ b/misc/hawkbit-upload.py
@@ -1114,18 +1114,23 @@ class HawkbitMgmtClient:
                 print(f"Cause: {e}")
         return True
 
-    def sort_distributions_by_version(self, dist_name: str):
-        from datetime import datetime
-
+    def sort_distributions_by_creation_time(self, dist_name: str):
         distributions = self.get_distributionsets_by_name(dist_name)
         if distributions is None:
             return None
 
+        def creation_time(distribution):
+            value = distribution.get(
+                "createdAt", distribution.get("lastModifiedAt", 0)
+            )
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return 0
+
         return sorted(
             distributions,
-            key=lambda dist: datetime.strptime(
-                dist["version"], "%Y-%m-%dT%H_%M_%S+0000"
-            ),
+            key=creation_time,
             reverse=True,
         )
 
@@ -1328,7 +1333,9 @@ if __name__ == "__main__":
             )
             exit(1)
 
-    sorted_distributionsets = client.sort_distributions_by_version(distribution_name)
+    sorted_distributionsets = client.sort_distributions_by_creation_time(
+        distribution_name
+    )
     # If the deployments are production images (nightly, beta, stable), we keep 3 copies of them, else 2.
     historics_to_keep = get_max_number_of_historic_distributions(distribution_name)
     print(f"\nRemoving extra distributions, keeping last {historics_to_keep}")

--- a/tests/test_hawkbit_upload.py
+++ b/tests/test_hawkbit_upload.py
@@ -1,0 +1,64 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+SCRIPT_PATH = Path(__file__).parents[1] / "misc" / "hawkbit-upload.py"
+SPEC = importlib.util.spec_from_file_location("hawkbit_upload", SCRIPT_PATH)
+HAWKBIT_UPLOAD = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(HAWKBIT_UPLOAD)
+
+
+class DistributionSortingTests(unittest.TestCase):
+    def setUp(self):
+        self.client = HAWKBIT_UPLOAD.HawkbitMgmtClient("hawkbit", 443)
+
+    def test_sorts_mixed_version_formats_by_creation_time(self):
+        self.client.get_distributionsets_by_name = lambda _name: [
+            {
+                "version": "2026M1340-stable",
+                "createdAt": 300,
+            },
+            {
+                "version": "2026-07-27T19_46_37+0000",
+                "createdAt": 100,
+            },
+            {
+                "version": "2026M1339-stable",
+                "createdAt": 200,
+            },
+        ]
+
+        distributions = self.client.sort_distributions_by_creation_time("stable EMMC")
+
+        self.assertEqual(
+            [distribution["version"] for distribution in distributions],
+            [
+                "2026M1340-stable",
+                "2026M1339-stable",
+                "2026-07-27T19_46_37+0000",
+            ],
+        )
+
+    def test_falls_back_to_last_modified_time(self):
+        self.client.get_distributionsets_by_name = lambda _name: [
+            {"version": "older", "lastModifiedAt": "100"},
+            {"version": "newer", "lastModifiedAt": "200"},
+        ]
+
+        distributions = self.client.sort_distributions_by_creation_time("stable EMMC")
+
+        self.assertEqual(
+            [distribution["version"] for distribution in distributions],
+            ["newer", "older"],
+        )
+
+    def test_returns_none_when_no_distributions_exist(self):
+        self.client.get_distributionsets_by_name = lambda _name: None
+
+        self.assertIsNone(
+            self.client.sort_distributions_by_creation_time("stable EMMC")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Use the generated image build version, such as `2026M1340-stable`, for the RAUC bundle manifest, artifact filename, Hawkbit software module, and distribution set.
- Reuse the version embedded in the EMMC bundle for the manual Hawkbit upload workflow.
- Sort distribution retention by Hawkbit creation time instead of parsing the user-facing version as a timestamp, allowing legacy timestamp versions and new image versions to coexist.

## Root cause
- The image workflow already generated and installed the channel-aware build version, but the bundle and Hawkbit upload independently generated timestamps.
- The retention cleanup coupled ordering to that timestamp format, so directly changing the uploaded version would have broken cleanup.

## Validation
- `python -m unittest discover -s tests -v`
- `python -m py_compile misc/hawkbit-upload.py tests/test_hawkbit_upload.py`
- `python -m black --check tests/test_hawkbit_upload.py`
- Parsed `.github/workflows/build-image-channel.yml` and `.github/workflows/upload-bundle.yml` with PyYAML.
- `bash -n make-ota.sh`
- `git diff --check`