### PR TITLE
Include meticulous-machine in image build metadata

### DIFF
--- a/generate-build-info.sh
+++ b/generate-build-info.sh
@@ -25,6 +25,8 @@ fi
 
 source config.sh
 
+MACHINE_SRC_DIR="$(git rev-parse --show-toplevel)"
+
 # Source the image-specific version overrides (same logic as update-sources.sh)
 if [[ "${IMAGE_NAME}" && "${IMAGE_NAME}" != "nightly" ]]; then
     VERSIONS_FILE="images/${IMAGE_NAME}.versions.sh"
@@ -39,19 +41,19 @@ elif [[ "${IMAGE_NAME}" == "nightly" ]]; then
 fi
 
 COMPONENT_NAMES=(
-    linux uboot atf imx-mkimage debian
+    meticulous-machine linux uboot atf imx-mkimage debian
     backend dial web-app watcher firmware
     rauc hawkbit psplash history-ui plotter-ui crash-reporter
 )
 
 COMPONENT_DIRS=(
-    "$LINUX_SRC_DIR" "$UBOOT_SRC_DIR" "$ATF_SRC_DIR" "$IMX_MKIMAGE_SRC_DIR" "$DEBIAN_SRC_DIR"
+    "$MACHINE_SRC_DIR" "$LINUX_SRC_DIR" "$UBOOT_SRC_DIR" "$ATF_SRC_DIR" "$IMX_MKIMAGE_SRC_DIR" "$DEBIAN_SRC_DIR"
     "$BACKEND_SRC_DIR" "$DIAL_SRC_DIR" "$WEB_APP_SRC_DIR" "$WATCHER_SRC_DIR" "$FIRMWARE_SRC_DIR"
     "$RAUC_SRC_DIR" "$HAWKBIT_SRC_DIR" "$PSPLASH_SRC_DIR" "$HISTORY_UI_SRC_DIR" "$PLOTTER_UI_SRC_DIR" "$CRASH_REPORTER_SRC_DIR"
 )
 
 COMPONENT_OPTIONAL=(
-    false false false false false
+    false false false false false false
     false false false false false
     false false false true true false
 )


### PR DESCRIPTION
## Summary
- Include the `meticulous-machine` checkout in image repository metadata.
- Record its commit in `/opt/summary.txt`, changelog version snapshots, and per-build changes so each image identifies the machine configuration and scripts used to generate its metadata.
- Treat the repository as a required image input, consistent with the other required components.

## Validation
- `bash -n generate-build-info.sh`
- `./generate-build-info.sh stable TEST-BUILD` in an isolated Git snapshot
- Parsed the generated changelog with `generate-changelog-html.py` and confirmed `meticulous-machine` is present in both `versions` and `changes`
- `git diff --check`