### PR TITLE
feat: retry idemptent hawkbit requests on 5xx server response code

### DIFF
--- a/misc/hawkbit-upload.py
+++ b/misc/hawkbit-upload.py
@@ -6,6 +6,7 @@
 
 import time
 import os
+import random
 import attr
 import requests as r
 import json
@@ -15,6 +16,13 @@ from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
 MAX_PRODUCTION_IMAGES_ON_SERVER = 3
 MAX_TESTING_IMAGES_ON_SERVER = 2
+
+# Retries for requests that are safe to replay. hawkBit occasionally answers a perfectly
+# valid request with a 5xx while it is under load, so retrying recovers the run instead of
+# failing the whole upload.
+RETRY_MAX_RETRIES = 3
+RETRY_DELAY_SECONDS = 1.0
+RETRY_JITTER_SECONDS = 0.2
 ROLLOUT_GROUP_CONDITIONS = {
     "successCondition": {"condition": "THRESHOLD", "expression": "90"},
     "successAction": {"action": "PAUSE", "expression": ""},
@@ -27,6 +35,18 @@ INTERNAL_TESTING_TARGETS = [
     "meticulousLayeredHoney-000000",
     "meticulousReverencedCoffeeCanister-99900776",
 ]
+
+
+def is_retryable_status(status_code: int) -> bool:
+    """A 5xx means hawkBit itself (or a proxy in front of it) failed, not the request."""
+    return 500 <= status_code < 600
+
+
+def retry_delay() -> float:
+    """Fixed delay with jitter, so parallel uploads do not retry in lockstep."""
+    jitter = random.uniform(-RETRY_JITTER_SECONDS, RETRY_JITTER_SECONDS)
+    return max(0.0, RETRY_DELAY_SECONDS + jitter)
+
 
 class HawkbitError(Exception):
     pass
@@ -65,6 +85,48 @@ class HawkbitMgmtClient:
             self.url = f"http://{self.host}:{self.port}/rest/v1/{{endpoint}}"
         self.id = HawkbitIdStore()
 
+    def _request_with_retry(
+        self,
+        description: str,
+        send_request,
+        retry: bool = True,
+        recovered_statuses: tuple = (),
+    ):
+        """
+        Calls `send_request` and replays it while hawkBit answers with a 5xx status.
+
+        Only for requests that are safe to replay: GET, PUT, DELETE and the endpoints that opt in
+        via `post(retry_on_server_error=True)`.
+
+        Returns `(response, recovered)`. `recovered` is True when a replay answered with one of
+        `recovered_statuses` *after* an earlier attempt had already failed with a 5xx, which means
+        that lost attempt did reach hawkBit after all. Outside of that window the status is
+        reported normally, so the caller still has to check the response itself.
+        """
+        attempts = RETRY_MAX_RETRIES + 1 if retry else 1
+        retried_after_server_error = False
+
+        for attempt in range(1, attempts + 1):
+            response = send_request()
+
+            if (
+                retried_after_server_error
+                and response.status_code in recovered_statuses
+            ):
+                return response, True
+
+            if not is_retryable_status(response.status_code) or attempt == attempts:
+                return response, False
+
+            delay = retry_delay()
+            print(
+                f"{description} failed with HTTP {response.status_code}, retrying in "
+                f"{delay:.2f}s (retry {attempt} of {RETRY_MAX_RETRIES})",
+                flush=True,
+            )
+            time.sleep(delay)
+            retried_after_server_error = True
+
     def get(self, endpoint: str):
         """
         Performs an authenticated HTTP GET request on `endpoint`.
@@ -76,10 +138,13 @@ class HawkbitMgmtClient:
             if endpoint.startswith("http")
             else self.url.format(endpoint=endpoint)
         )
-        req = r.get(
-            url,
-            headers={"Content-Type": "application/json;charset=UTF-8"},
-            auth=(self.username, self.password),
+        req, _ = self._request_with_retry(
+            f"GET {url}",
+            lambda: r.get(
+                url,
+                headers={"Content-Type": "application/json;charset=UTF-8"},
+                auth=(self.username, self.password),
+            ),
         )
         if req.status_code != 200:
             try:
@@ -91,7 +156,13 @@ class HawkbitMgmtClient:
 
         return req.json()
 
-    def post(self, endpoint: str, json_data: dict = None, file_name: str = None):
+    def post(
+        self,
+        endpoint: str,
+        json_data: dict = None,
+        file_name: str = None,
+        retry_on_server_error: bool = False,
+    ):
         """
         Performs an authenticated HTTP POST request on `endpoint`.
         If `json_data` is given, it is sent along with the request and JSON data is expected in the
@@ -100,8 +171,18 @@ class HawkbitMgmtClient:
         expected in the response, which is in that case returned.
         json_data and file_name must not be specified in the same call.
         Endpoint can either be a full URL or a path relative to /rest/v1/.
+
+        POST is not idempotent in general, so 5xx responses are not retried by default. Pass
+        `retry_on_server_error=True` only for endpoints where replaying the identical request
+        cannot create a second resource or duplicate a side effect. In particular the creating
+        endpoints (softwaremodules, distributionsets, rollouts, targets, targetfilters) must not
+        opt in: if hawkBit created the entity and only then failed to answer, the replay hits the
+        uniqueness constraint and reports a 409 instead of the original result.
         """
         assert not (json_data and file_name)
+        # The multipart encoder wraps an already opened file handle and is consumed by the first
+        # attempt, so an upload cannot be replayed as-is.
+        assert not (file_name and retry_on_server_error)
 
         url = (
             endpoint
@@ -136,12 +217,16 @@ class HawkbitMgmtClient:
         )
         headers = {"Content-Type": monitor.content_type} if monitor else headers
 
-        req = r.post(
-            url,
-            headers=headers,
-            auth=(self.username, self.password),
-            json=json_data,
-            data=monitor,
+        req, _ = self._request_with_retry(
+            f"POST {url}",
+            lambda: r.post(
+                url,
+                headers=headers,
+                auth=(self.username, self.password),
+                json=json_data,
+                data=monitor,
+            ),
+            retry=retry_on_server_error,
         )
 
         if not 200 <= req.status_code < 300:
@@ -162,6 +247,9 @@ class HawkbitMgmtClient:
         Performs an authenticated HTTP PUT request on `endpoint`. `json_data` is sent along with
         the request.
         `endpoint` can either be a full URL or a path relative to /rest/v1/.
+
+        Every PUT of this client replaces the state of an existing resource, so replaying it after
+        a 5xx converges on the same result.
         """
         url = (
             endpoint
@@ -169,7 +257,10 @@ class HawkbitMgmtClient:
             else self.url.format(endpoint=endpoint)
         )
 
-        req = r.put(url, auth=(self.username, self.password), json=json_data)
+        req, _ = self._request_with_retry(
+            f"PUT {url}",
+            lambda: r.put(url, auth=(self.username, self.password), json=json_data),
+        )
         if not 200 <= req.status_code < 300:
             try:
                 raise HawkbitError(f"HTTP error {req.status_code}: {req.json()}")
@@ -183,6 +274,12 @@ class HawkbitMgmtClient:
         """
         Performs an authenticated HTTP DELETE request on endpoint.
         Endpoint can either be a full URL or a path relative to /rest/v1/.
+
+        Retried on 5xx like the other replayable requests. If hawkBit removed the resource and
+        only then failed to answer, the replay reports a 404. That 404 counts as success only
+        once an earlier attempt has failed with a 5xx, because in that window our own lost
+        attempt is what removed the resource. A 404 on the first attempt still raises, so a
+        genuinely missing resource is not silently swallowed.
         """
         url = (
             endpoint
@@ -190,7 +287,19 @@ class HawkbitMgmtClient:
             else self.url.format(endpoint=endpoint)
         )
 
-        req = r.delete(url, auth=(self.username, self.password))
+        req, recovered = self._request_with_retry(
+            f"DELETE {url}",
+            lambda: r.delete(url, auth=(self.username, self.password)),
+            recovered_statuses=(404,),
+        )
+        if recovered:
+            print(
+                f"DELETE {url} answered 404 after a server error, "
+                "treating the resource as already deleted",
+                flush=True,
+            )
+            return
+
         if not 200 <= req.status_code < 300:
             try:
                 raise HawkbitError(f"HTTP error {req.status_code}: {req.json()}")
@@ -370,7 +479,11 @@ class HawkbitMgmtClient:
         endpoint = f"targetfilters/{filter_id}/autoAssignDS"
 
         try:
-            response = self.post(endpoint, json_data=json_data)
+            # Sets the auto assignment of the filter to a single value, so replaying it after a
+            # 5xx leaves the filter in the exact same state.
+            response = self.post(
+                endpoint, json_data=json_data, retry_on_server_error=True
+            )
 
             if response is not None:
                 return response

--- a/tests/test_hawkbit_upload.py
+++ b/tests/test_hawkbit_upload.py
@@ -1,11 +1,20 @@
 import importlib.util
 from pathlib import Path
 import unittest
+from unittest import mock
 
 SCRIPT_PATH = Path(__file__).parents[1] / "misc" / "hawkbit-upload.py"
 SPEC = importlib.util.spec_from_file_location("hawkbit_upload", SCRIPT_PATH)
 HAWKBIT_UPLOAD = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(HAWKBIT_UPLOAD)
+
+
+def fake_response(status_code, json_body=None):
+    response = mock.Mock()
+    response.status_code = status_code
+    response.json.return_value = json_body if json_body is not None else {}
+    response.content = b"{}"
+    return response
 
 
 class DistributionSortingTests(unittest.TestCase):
@@ -57,6 +66,152 @@ class DistributionSortingTests(unittest.TestCase):
 
         self.assertIsNone(
             self.client.sort_distributions_by_creation_time("stable EMMC")
+        )
+
+
+class ServerErrorRetryTests(unittest.TestCase):
+    def setUp(self):
+        self.client = HAWKBIT_UPLOAD.HawkbitMgmtClient("hawkbit", 443)
+
+        sleep_patcher = mock.patch.object(HAWKBIT_UPLOAD.time, "sleep")
+        self.sleep = sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+    def test_get_retries_until_it_succeeds(self):
+        responses = [
+            fake_response(500),
+            fake_response(503),
+            fake_response(200, {"value": "ok"}),
+        ]
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "get", side_effect=responses
+        ) as get_mock:
+            self.assertEqual(self.client.get("system/configs/x"), {"value": "ok"})
+
+        self.assertEqual(get_mock.call_count, 3)
+        self.assertEqual(self.sleep.call_count, 2)
+
+    def test_get_gives_up_after_the_configured_retries(self):
+        responses = [fake_response(500)] * (HAWKBIT_UPLOAD.RETRY_MAX_RETRIES + 1)
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "get", side_effect=responses
+        ) as get_mock:
+            with self.assertRaises(HAWKBIT_UPLOAD.HawkbitError):
+                self.client.get("system/configs/x")
+
+        self.assertEqual(get_mock.call_count, HAWKBIT_UPLOAD.RETRY_MAX_RETRIES + 1)
+
+    def test_client_errors_are_not_retried(self):
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "get", return_value=fake_response(404)
+        ) as get_mock:
+            with self.assertRaises(HAWKBIT_UPLOAD.HawkbitError):
+                self.client.get("targets/does-not-exist")
+
+        self.assertEqual(get_mock.call_count, 1)
+
+    def test_put_retries(self):
+        responses = [fake_response(500), fake_response(200, {"id": 1})]
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "put", side_effect=responses
+        ) as put_mock:
+            self.client.put("distributionsets/1", {"version": "2"})
+
+        self.assertEqual(put_mock.call_count, 2)
+
+    def test_post_does_not_retry_by_default(self):
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "post", return_value=fake_response(500)
+        ) as post_mock:
+            with self.assertRaises(HAWKBIT_UPLOAD.HawkbitError):
+                self.client.post("distributionsets", [{"name": "stable EMMC"}])
+
+        self.assertEqual(post_mock.call_count, 1)
+
+    def test_post_retries_when_the_endpoint_opts_in(self):
+        responses = [fake_response(500), fake_response(200, {"id": 1})]
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "post", side_effect=responses
+        ) as post_mock:
+            self.client.post(
+                "targetfilters/1/autoAssignDS",
+                json_data={"id": 1},
+                retry_on_server_error=True,
+            )
+
+        self.assertEqual(post_mock.call_count, 2)
+
+    def test_assign_ds_to_targetfilter_opts_into_retrying(self):
+        responses = [fake_response(500), fake_response(200, {"id": 1})]
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "post", side_effect=responses
+        ) as post_mock:
+            self.client.assignDS_to_targetfilter("1", "2")
+
+        self.assertEqual(post_mock.call_count, 2)
+
+    def test_delete_retries_until_it_succeeds(self):
+        responses = [fake_response(500), fake_response(200)]
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "delete", side_effect=responses
+        ) as delete_mock:
+            self.client.delete("distributionsets/1")
+
+        self.assertEqual(delete_mock.call_count, 2)
+
+    def test_delete_gives_up_after_the_configured_retries(self):
+        responses = [fake_response(500)] * (HAWKBIT_UPLOAD.RETRY_MAX_RETRIES + 1)
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "delete", side_effect=responses
+        ) as delete_mock:
+            with self.assertRaises(HAWKBIT_UPLOAD.HawkbitError):
+                self.client.delete("distributionsets/1")
+
+        self.assertEqual(delete_mock.call_count, HAWKBIT_UPLOAD.RETRY_MAX_RETRIES + 1)
+
+    def test_delete_accepts_404_once_a_retry_is_under_way(self):
+        # The lost attempt did reach hawkBit, so the resource really is gone.
+        responses = [fake_response(502), fake_response(404)]
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "delete", side_effect=responses
+        ) as delete_mock:
+            self.client.delete("distributionsets/1")
+
+        self.assertEqual(delete_mock.call_count, 2)
+
+    def test_delete_still_raises_on_a_404_from_the_first_attempt(self):
+        with mock.patch.object(
+            HAWKBIT_UPLOAD.r, "delete", return_value=fake_response(404)
+        ) as delete_mock:
+            with self.assertRaises(HAWKBIT_UPLOAD.HawkbitError):
+                self.client.delete("distributionsets/does-not-exist")
+
+        self.assertEqual(delete_mock.call_count, 1)
+
+    def test_a_404_is_not_recovered_for_other_methods(self):
+        responses = [fake_response(500), fake_response(404)]
+        with mock.patch.object(HAWKBIT_UPLOAD.r, "get", side_effect=responses):
+            with self.assertRaises(HAWKBIT_UPLOAD.HawkbitError):
+                self.client.get("distributionsets/1")
+
+    def test_artifact_upload_cannot_opt_into_retrying(self):
+        with self.assertRaises(AssertionError):
+            self.client.post(
+                "softwaremodules/1/artifacts",
+                file_name=str(SCRIPT_PATH),
+                retry_on_server_error=True,
+            )
+
+    def test_retry_delay_stays_within_the_configured_jitter(self):
+        delays = [HAWKBIT_UPLOAD.retry_delay() for _ in range(1000)]
+
+        self.assertGreaterEqual(
+            min(delays),
+            HAWKBIT_UPLOAD.RETRY_DELAY_SECONDS - HAWKBIT_UPLOAD.RETRY_JITTER_SECONDS,
+        )
+        self.assertLessEqual(
+            max(delays),
+            HAWKBIT_UPLOAD.RETRY_DELAY_SECONDS + HAWKBIT_UPLOAD.RETRY_JITTER_SECONDS,
         )
 
 


### PR DESCRIPTION
When hawkbit returns a 5xx server error response code we retry it as long as in doing so we do not duplicate a side effect