### PR TITLE
Define Espresso E2E coverage contract

### DIFF
--- a/.github/workflows/validate-e2e-contract.yml
+++ b/.github/workflows/validate-e2e-contract.yml
@@ -1,0 +1,84 @@
+name: Validate E2E contract inventory
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/validate-e2e-contract.yml"
+      - "docs/testing/e2e-contract-inventory.md"
+      - "e2e/contracts/**"
+      - "scripts/validate_e2e_contract.py"
+      - "tests/test_e2e_contract.py"
+      - "config.sh"
+      - "images/*.versions.sh"
+      - "system-services/**"
+      - "config/etc/nginx/sites-available/default"
+  push:
+    branches:
+      - nightly
+    paths:
+      - ".github/workflows/validate-e2e-contract.yml"
+      - "docs/testing/e2e-contract-inventory.md"
+      - "e2e/contracts/**"
+      - "scripts/validate_e2e_contract.py"
+      - "tests/test_e2e_contract.py"
+      - "config.sh"
+      - "images/*.versions.sh"
+      - "system-services/**"
+      - "config/etc/nginx/sites-available/default"
+  schedule:
+    - cron: "23 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout meticulous-machine
+        uses: actions/checkout@v4
+        with:
+          path: meticulous-machine
+
+      - name: Checkout Dial nightly
+        uses: actions/checkout@v4
+        with:
+          repository: MeticulousHome/meticulous-dial
+          ref: nightly
+          path: meticulous-dial
+          token: ${{ secrets.GH_ORG_WORKFLOW }}
+
+      - name: Checkout backend nightly
+        uses: actions/checkout@v4
+        with:
+          repository: MeticulousHome/meticulous-backend
+          ref: nightly
+          path: meticulous-backend
+          token: ${{ secrets.GH_ORG_WORKFLOW }}
+
+      - name: Checkout firmware nightly
+        uses: actions/checkout@v4
+        with:
+          repository: MeticulousHome/EspressoFirmware
+          ref: nightly
+          path: EspressoFirmware
+          token: ${{ secrets.GH_ORG_WORKFLOW }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Validate contract structure
+        working-directory: meticulous-machine
+        run: python -m unittest discover -s tests -p 'test_e2e_contract.py' -v
+
+      - name: Validate contract against source
+        working-directory: meticulous-machine
+        run: >-
+          python scripts/validate_e2e_contract.py
+          --machine .
+          --dial ../meticulous-dial
+          --backend ../meticulous-backend
+          --firmware ../EspressoFirmware

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bundle.rauc
 *.raucb
 .venv
 venv
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ sudo make-rootfs.sh --all
 sudo make-sdcard.sh --image
 ```
 
+## Testing
+
+The cross-repository Espresso E2E scope, planned product journeys, known gaps,
+and drift-validation commands are documented in
+[`docs/testing/e2e-contract-inventory.md`](docs/testing/e2e-contract-inventory.md).
+The machine-readable contract lives in `e2e/contracts/coverage.json`.
+
+Validate the inventory itself with:
+
+```bash
+python scripts/validate_e2e_contract.py --self-check
+python -m unittest discover -s tests -p 'test_e2e_contract.py' -v
+```
+
 ## Running on non-ubuntu > 24.04 systems (macOS / docker)
 For building on macOS or non-ubuntu systems we offer the `./run-in-container.sh` script. It will start an ubuntu container with all dependencies
 installed

--- a/docs/testing/e2e-contract-inventory.md
+++ b/docs/testing/e2e-contract-inventory.md
@@ -1,0 +1,121 @@
+# Espresso end-to-end test contract inventory
+
+## Purpose
+
+This document defines the scope that the Espresso end-to-end program must
+cover before individual test runners are implemented. The machine-readable
+source of truth is [`e2e/contracts/coverage.json`](../../e2e/contracts/coverage.json).
+
+The inventory is owned by `meticulous-machine` because that repository selects
+the exact component sources used by an image. Component repositories remain
+responsible for their local test implementations; this inventory defines the
+cross-repository contract and complete-machine journeys.
+
+## Captured baseline
+
+The first baseline was captured from the `nightly` branches on 2026-08-10:
+
+| Repository | Captured commit | Authority inspected |
+| --- | --- | --- |
+| meticulous-machine | `220dbcbc41d64069c85f98f46b7c2808c86ee20d` | `config.sh`, image channel manifests, Nginx and systemd units |
+| meticulous-dial | `7f4482871d4feb73a5518f26954f33256c3c3d19` | `ScreenType`, route registry, API calls and Socket.IO usage |
+| meticulous-backend | `69086ade492fffdb4d304b47281239ca560bb485` | API registration, Socket.IO, allowed actions and emulator traces |
+| EspressoFirmware | `f201fbbd4a85cc7c47127f900268700e21468a03` | `FikaUart` incoming keys/actions and backend-consumed messages |
+
+The validator intentionally compares discovered source surfaces with the
+manifest. Adding or removing an API, route, screen, event, action or image
+component requires an explicit inventory update.
+
+## Current inventory
+
+The captured contract contains:
+
+- 60 registered Dial screens, grouped by brew lifecycle, profile authoring,
+  settings, Wi-Fi, advanced settings and diagnostics.
+- 36 API-client methods called by Dial.
+- 9 Socket.IO events consumed by Dial and 3 emitted by Dial.
+- 57 backend API route patterns, 4 inbound Socket.IO events and 9 outbound
+  Socket.IO events.
+- 4 existing backend emulation scenarios: idle, home, purge and espresso.
+- 5 firmware UART command families, 13 actions and 11 outbound message
+  families.
+- 19 component repositories declared by the image integrator.
+- 10 product journeys targeted for future automated execution.
+
+Counts are descriptive, not a quality metric. A passing inventory validation
+means the documented contract matches source; it does not yet mean the product
+journeys execute successfully.
+
+## Planned journeys
+
+`P0` journeys are release-critical:
+
+1. Reach every registered Dial route through production navigation.
+2. Boot the software stack and reach a usable ready/profile state.
+3. Select, edit, save and reload a profile.
+4. Run a complete simulated espresso lifecycle and record history.
+5. Abort a shot and recover safely.
+6. Exercise home, purge, tare and calibration at the appropriate test tier.
+7. Recover from backend REST/Socket disconnection.
+
+`P1` journeys cover settings persistence, Wi-Fi lifecycle, update state and
+privacy-safe diagnostics.
+
+Each journey declares one or more execution tiers:
+
+- `simulated`: host runner with real Dial/backend processes and simulated ESP.
+- `rootfs`: packages, services and routing from the assembled ARM64 rootfs.
+- `hil`: physical i.MX8/Variscite and/or ESP32-S3 fixture with safe hardware
+  controls.
+
+All journeys are marked `planned`. Their status must only change to
+`implemented` when an executable test exists and passes in its declared tier.
+
+## Known gaps found during inventory
+
+- Dial subscribes to `water_status`, but no literal backend emitter exists in
+  the captured source. Confirm whether the consolidated `status` event replaced
+  it before encoding expected behavior.
+- Backend emulation contains useful recorded scenarios but lacks a deterministic
+  test-only reset/scenario control API.
+- The image workflow builds and uploads artifacts without booting the produced
+  system or checking runtime service health.
+
+These are evidence-backed gaps, not assumed defects.
+
+## Validation
+
+Validate manifest structure only:
+
+```bash
+python scripts/validate_e2e_contract.py --self-check
+```
+
+Validate against four clean source checkouts:
+
+```bash
+python scripts/validate_e2e_contract.py \
+  --machine /path/to/meticulous-machine \
+  --dial /path/to/meticulous-dial \
+  --backend /path/to/meticulous-backend \
+  --firmware /path/to/EspressoFirmware
+```
+
+Run the repository tests:
+
+```bash
+python -m unittest discover -s tests -p 'test_e2e_contract.py' -v
+```
+
+When validation reports `not inventoried`, inspect the source change and add it
+to the correct group or contract. When it reports `missing from source`, remove
+the item only after confirming that the product surface was intentionally
+deleted or renamed. Do not blindly regenerate the manifest, because review of
+contract changes is the purpose of this gate.
+
+## What this milestone does not prove
+
+This milestone does not open Dial, run an espresso, boot an image or actuate
+hardware. It establishes the audited coverage contract and drift detection
+needed to implement those tests without silently omitting screens or protocol
+surfaces. Executable Dial/backend journeys are the next milestone.

--- a/e2e/contracts/coverage.json
+++ b/e2e/contracts/coverage.json
@@ -1,0 +1,415 @@
+{
+  "schema_version": 1,
+  "captured_at": "2026-08-10",
+  "source_snapshot": {
+    "meticulous-machine": "220dbcbc41d64069c85f98f46b7c2808c86ee20d",
+    "meticulous-dial": "7f4482871d4feb73a5518f26954f33256c3c3d19",
+    "meticulous-backend": "69086ade492fffdb4d304b47281239ca560bb485",
+    "EspressoFirmware": "f201fbbd4a85cc7c47127f900268700e21468a03"
+  },
+  "dial": {
+    "screen_groups": {
+      "brew_lifecycle": [
+        "ready",
+        "profileHome",
+        "barometer",
+        "manual-purge",
+        "heating",
+        "heat_timeout_after_shot",
+        "brewComplete",
+        "idle",
+        "shot_history"
+      ],
+      "profile_authoring": [
+        "pressetSettings",
+        "name",
+        "pressure",
+        "time",
+        "weight",
+        "flow",
+        "temperature",
+        "piston_position",
+        "motor_power",
+        "dose",
+        "output",
+        "pressetProfileImage",
+        "defaultProfiles",
+        "defaultProfileDetails"
+      ],
+      "settings": [
+        "settings",
+        "quick-settings",
+        "brewSettings",
+        "scrollDirections"
+      ],
+      "wifi": [
+        "wifiSettings",
+        "wifiModeSettings",
+        "wifiQrMenu",
+        "wifiDetails",
+        "connectWifiMenu",
+        "selectWifi",
+        "connectWifiViaApp",
+        "enterWifiPassword",
+        "KnownWifi",
+        "deleteKnowWifiMenu"
+      ],
+      "advanced": [
+        "advancedSettings",
+        "deviceInfo",
+        "updateChannel",
+        "idleScreenSettings",
+        "timeDate",
+        "timeZoneConfig",
+        "selectLetterCountry",
+        "countrySettings",
+        "timeZoneSettings",
+        "timeConfig",
+        "dateConfig",
+        "calibrateScale",
+        "factoryReset",
+        "retraction_volume",
+        "manufacturingSettings",
+        "displayAlignment",
+        "masterCalibrationLock",
+        "deviceInfoQR"
+      ],
+      "support_and_diagnostics": [
+        "notifications",
+        "bug-report",
+        "OSStatus",
+        "snake",
+        "unlock"
+      ]
+    },
+    "api_methods": [
+      "acknowledgeNotification",
+      "connectToWiFi",
+      "createReport",
+      "deleteProfile",
+      "deleteWifi",
+      "executeAction",
+      "fetchAllProfiles",
+      "getDefaultProfiles",
+      "getDeviceInfo",
+      "getDraftReport",
+      "getLastProfile",
+      "getLastShot",
+      "getManufacturingMenuItems",
+      "getMeticulousReportTracking",
+      "getNotifications",
+      "getOSStatus",
+      "getProfileDefaultImages",
+      "getProfileImage",
+      "getProfileImageUrl",
+      "getRootPassword",
+      "getSettings",
+      "getTimezoneRegion",
+      "getWiFiQR",
+      "getWiFiQRURL",
+      "getWiFiStatus",
+      "listAvailableWiFi",
+      "loadProfileFromJSON",
+      "markSubmittedReport",
+      "saveProfile",
+      "searchHistory",
+      "setBrightness",
+      "setTime",
+      "setWiFiConfig",
+      "updateManufacturingSettings",
+      "updateReport",
+      "updateSetting"
+    ],
+    "socket_receives": [
+      "OSUpdate",
+      "button",
+      "heater_status",
+      "notification",
+      "profile",
+      "profileHover",
+      "sensors",
+      "status",
+      "water_status"
+    ],
+    "socket_emits": [
+      "action",
+      "calibrate",
+      "profileHover"
+    ]
+  },
+  "backend": {
+    "api_routes": [
+      "/action/(.*)",
+      "/history",
+      "/history/current",
+      "/history/debug",
+      "/history/debug.zip",
+      "/history/debug/(.*)",
+      "/history/files",
+      "/history/files/(.*)",
+      "/history/last",
+      "/history/last-debug-file",
+      "/history/rating/(.*)",
+      "/history/search",
+      "/history/stats",
+      "/machine",
+      "/machine/OS_update_status",
+      "/machine/backlight",
+      "/machine/factory_reset",
+      "/machine/root-password",
+      "/machine/time",
+      "/manufacturing[/]*",
+      "/notifications",
+      "/notifications/acknowledge",
+      "/profile/changes",
+      "/profile/defaults",
+      "/profile/delete/([0-9a-fA-F-]+)",
+      "/profile/get/([0-9a-fA-F-]+)",
+      "/profile/image([/]*)",
+      "/profile/image/(.*)",
+      "/profile/last",
+      "/profile/legacy",
+      "/profile/list",
+      "/profile/load",
+      "/profile/load/([0-9a-fA-F-]+)",
+      "/profile/save",
+      "/profile/selected",
+      "/reports/create",
+      "/reports/draft/([^/]+)",
+      "/reports/list",
+      "/reports/submit",
+      "/scaleCalibrate",
+      "/serial",
+      "/settings[/]*(.*)",
+      "/smoke-validation",
+      "/sounds/list",
+      "/sounds/play/(.*)",
+      "/sounds/theme/get",
+      "/sounds/theme/list",
+      "/sounds/theme/set/(.*)",
+      "/sounds/theme/upload",
+      "/timezones/(.*)",
+      "/update/firmware",
+      "/wifi/config",
+      "/wifi/config/qr.png",
+      "/wifi/connect",
+      "/wifi/delete",
+      "/wifi/list",
+      "/wifi/repair"
+    ],
+    "socket_receives": [
+      "action",
+      "calibrate",
+      "notification",
+      "profileHover"
+    ],
+    "socket_emits": [
+      "OSUpdate",
+      "button",
+      "heater_status",
+      "notification",
+      "profile",
+      "profileHover",
+      "sensors",
+      "settings",
+      "status"
+    ],
+    "emulation_scenarios": [
+      "idle",
+      "home",
+      "purge",
+      "espresso"
+    ],
+    "allowed_actions": [
+      "abort",
+      "continue",
+      "home",
+      "preheat",
+      "purge",
+      "reset",
+      "scale_master_calibration",
+      "start",
+      "stop",
+      "tare"
+    ]
+  },
+  "firmware": {
+    "uart_incoming_keys": [
+      "action",
+      "hash",
+      "heater_timeout",
+      "json",
+      "nvs_request"
+    ],
+    "uart_actions": [
+      "calibration",
+      "continue",
+      "home",
+      "idle",
+      "info",
+      "json",
+      "manual_control",
+      "preheat",
+      "purge",
+      "scale_master_calibration",
+      "start",
+      "stop",
+      "tare"
+    ],
+    "uart_outbound_messages": [
+      "Data",
+      "ERROR",
+      "ESPInfo",
+      "Event",
+      "HeaterTimeoutInfo",
+      "Log",
+      "MANUAL_CONTROL",
+      "Notify",
+      "Sensors",
+      "TaskInfo",
+      "nvs_response"
+    ]
+  },
+  "image": {
+    "component_sources": [
+      "ATF",
+      "BACKEND",
+      "CRASH_REPORTER",
+      "DASH",
+      "DEBIAN",
+      "DIAL",
+      "FIRMWARE",
+      "HAWKBIT",
+      "IMX_MKIMAGE",
+      "LINUX",
+      "MLANUTL",
+      "MOBILE",
+      "MWIFIEX",
+      "PLOTTER_UI",
+      "PSPLASH",
+      "RAUC",
+      "UBOOT",
+      "WATCHER",
+      "WEB_APP"
+    ],
+    "required_services": [
+      "meticulous-backend.service",
+      "meticulous-dial.service",
+      "meticulous-watcher.service",
+      "pulseaudio.service",
+      "rauc-hawkbit-updater.service",
+      "weston.service"
+    ],
+    "nginx_contracts": [
+      "location / {",
+      "location /debug {",
+      "location /debug/plotter-ui {",
+      "^/(socket\\.io|api)",
+      "^/health"
+    ],
+    "channels": [
+      "nightly",
+      "beta",
+      "stable"
+    ]
+  },
+  "journeys": [
+    {
+      "id": "dial-all-routes-reachable",
+      "priority": "P0",
+      "tiers": ["simulated", "rootfs", "hil"],
+      "screen_groups": ["*"],
+      "summary": "Open every registered Dial route through production navigation and return without a render or state error.",
+      "status": "planned"
+    },
+    {
+      "id": "boot-to-ready",
+      "priority": "P0",
+      "tiers": ["simulated", "rootfs", "hil"],
+      "screen_groups": ["brew_lifecycle"],
+      "summary": "Start backend and Dial, receive machine state and reach the ready/profile selection experience.",
+      "status": "planned"
+    },
+    {
+      "id": "profile-select-edit-persist",
+      "priority": "P0",
+      "tiers": ["simulated", "hil"],
+      "screen_groups": ["profile_authoring"],
+      "summary": "Browse, select, edit, save and reload a profile while preserving its selected identity.",
+      "status": "planned"
+    },
+    {
+      "id": "espresso-complete",
+      "priority": "P0",
+      "tiers": ["simulated", "hil"],
+      "screen_groups": ["brew_lifecycle"],
+      "summary": "Load a profile, start, heat, brew, complete, remove the cup and return to idle with history recorded.",
+      "status": "planned"
+    },
+    {
+      "id": "espresso-abort-and-recover",
+      "priority": "P0",
+      "tiers": ["simulated", "hil"],
+      "screen_groups": ["brew_lifecycle"],
+      "summary": "Abort an active shot, stop outputs and recover to a usable idle/home state.",
+      "status": "planned"
+    },
+    {
+      "id": "maintenance-actions",
+      "priority": "P0",
+      "tiers": ["simulated", "hil"],
+      "screen_groups": ["brew_lifecycle", "advanced"],
+      "summary": "Exercise home, purge, tare and scale calibration with explicit simulated versus hardware assertions.",
+      "status": "planned"
+    },
+    {
+      "id": "settings-persistence",
+      "priority": "P1",
+      "tiers": ["simulated", "rootfs", "hil"],
+      "screen_groups": ["settings", "advanced"],
+      "summary": "Change supported settings, restart the stack and verify persisted values and resulting UI state.",
+      "status": "planned"
+    },
+    {
+      "id": "wifi-lifecycle",
+      "priority": "P1",
+      "tiers": ["simulated", "hil"],
+      "screen_groups": ["wifi"],
+      "summary": "List, connect, inspect, repair and delete Wi-Fi configuration, including failure and recovery states.",
+      "status": "planned"
+    },
+    {
+      "id": "backend-disconnect-recovery",
+      "priority": "P0",
+      "tiers": ["simulated", "rootfs", "hil"],
+      "screen_groups": ["brew_lifecycle", "support_and_diagnostics"],
+      "summary": "Lose and restore REST/Socket connectivity without leaving Dial permanently stale or unusable.",
+      "status": "planned"
+    },
+    {
+      "id": "update-and-diagnostics",
+      "priority": "P1",
+      "tiers": ["rootfs", "hil"],
+      "screen_groups": ["advanced", "support_and_diagnostics"],
+      "summary": "Expose image/device information, update state, notifications and privacy-safe diagnostic reporting.",
+      "status": "planned"
+    }
+  ],
+  "known_gaps": [
+    {
+      "id": "dial-water-status-without-static-backend-emitter",
+      "evidence": "Dial subscribes to water_status, while no literal backend Socket.IO emitter is present in the captured nightly source.",
+      "next_step": "Confirm whether status replaces this legacy event before implementing the socket contract tests."
+    },
+    {
+      "id": "backend-emulation-has-no-deterministic-control-api",
+      "evidence": "The emulator selects recorded idle, home, purge and espresso streams from UART commands but has no reset/scenario test API.",
+      "next_step": "Add an emulation-only control surface in the vertical-slice milestone."
+    },
+    {
+      "id": "image-build-has-no-runtime-boot-gate",
+      "evidence": "The image workflow uploads rootfs, SD/eMMC, RAUC and deployment artifacts without starting the produced system.",
+      "next_step": "Add rootfs smoke and HIL boot gates in the image milestone."
+    }
+  ]
+}

--- a/scripts/validate_e2e_contract.py
+++ b/scripts/validate_e2e_contract.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Validate the E2E coverage inventory against checked-out component sources."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "e2e" / "contracts" / "coverage.json"
+
+
+def load_manifest(path: Path = DEFAULT_MANIFEST) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def flatten_screen_groups(manifest: dict) -> list[str]:
+    return [
+        screen
+        for screens in manifest["dial"]["screen_groups"].values()
+        for screen in screens
+    ]
+
+
+def _duplicates(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    return sorted(duplicates)
+
+
+def validate_manifest(manifest: dict) -> list[str]:
+    errors: list[str] = []
+    if manifest.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    screens = flatten_screen_groups(manifest)
+    duplicates = _duplicates(screens)
+    if duplicates:
+        errors.append(f"Dial screens assigned to multiple groups: {duplicates}")
+
+    journey_ids = [journey["id"] for journey in manifest.get("journeys", [])]
+    duplicate_journeys = _duplicates(journey_ids)
+    if duplicate_journeys:
+        errors.append(f"Duplicate journey ids: {duplicate_journeys}")
+
+    groups = set(manifest["dial"]["screen_groups"])
+    valid_tiers = {"simulated", "rootfs", "hil"}
+    valid_priorities = {"P0", "P1", "P2"}
+    valid_statuses = {"planned", "implemented", "blocked"}
+    for journey in manifest.get("journeys", []):
+        unknown_groups = set(journey.get("screen_groups", [])) - groups - {"*"}
+        if unknown_groups:
+            errors.append(
+                f"Journey {journey['id']} references unknown screen groups: "
+                f"{sorted(unknown_groups)}"
+            )
+        unknown_tiers = set(journey.get("tiers", [])) - valid_tiers
+        if unknown_tiers:
+            errors.append(
+                f"Journey {journey['id']} references unknown tiers: {sorted(unknown_tiers)}"
+            )
+        if journey.get("priority") not in valid_priorities:
+            errors.append(f"Journey {journey['id']} has an invalid priority")
+        if journey.get("status") not in valid_statuses:
+            errors.append(f"Journey {journey['id']} has an invalid status")
+        if not journey.get("summary"):
+            errors.append(f"Journey {journey['id']} needs a summary")
+
+    for section_name, values in (
+        ("dial.api_methods", manifest["dial"]["api_methods"]),
+        ("dial.socket_receives", manifest["dial"]["socket_receives"]),
+        ("dial.socket_emits", manifest["dial"]["socket_emits"]),
+        ("backend.api_routes", manifest["backend"]["api_routes"]),
+        ("backend.socket_receives", manifest["backend"]["socket_receives"]),
+        ("backend.socket_emits", manifest["backend"]["socket_emits"]),
+        ("firmware.uart_incoming_keys", manifest["firmware"]["uart_incoming_keys"]),
+        ("firmware.uart_actions", manifest["firmware"]["uart_actions"]),
+        ("image.component_sources", manifest["image"]["component_sources"]),
+    ):
+        duplicates = _duplicates(values)
+        if duplicates:
+            errors.append(f"{section_name} contains duplicates: {duplicates}")
+
+    if not any(
+        journey.get("screen_groups") == ["*"] for journey in manifest["journeys"]
+    ):
+        errors.append(
+            "At least one journey must explicitly cover every Dial screen group"
+        )
+
+    return errors
+
+
+def _read_tree(root: Path, pattern: str) -> str:
+    # The NUL sentinel prevents a regex from accidentally matching across two
+    # unrelated files when one ends with an incomplete-looking expression.
+    return "\n\0\n".join(
+        path.read_text(encoding="utf-8", errors="replace")
+        for path in sorted(root.glob(pattern))
+        if path.is_file()
+    )
+
+
+def _compare(label: str, actual: Iterable[str], expected: Iterable[str]) -> list[str]:
+    actual_set = set(actual)
+    expected_set = set(expected)
+    errors: list[str] = []
+    missing = sorted(expected_set - actual_set)
+    unexpected = sorted(actual_set - expected_set)
+    if missing:
+        errors.append(f"{label}: missing from source: {missing}")
+    if unexpected:
+        errors.append(f"{label}: not inventoried: {unexpected}")
+    return errors
+
+
+def discover_dial(dial_root: Path) -> dict[str, set[str]]:
+    screen_source = (
+        dial_root / "src/components/store/features/screens/screens-slice.ts"
+    ).read_text(encoding="utf-8")
+    screen_block = re.search(
+        r"export type ScreenType\s*=\s*(?P<body>.*?);", screen_source, re.DOTALL
+    )
+    if not screen_block:
+        raise ValueError("Could not find Dial ScreenType")
+    screens = set(re.findall(r"\|\s*'([^']+)'", screen_block.group("body")))
+
+    route_source = (dial_root / "src/navigation/routes.ts").read_text(encoding="utf-8")
+    route_matches = re.findall(
+        r"^\s{2}(?:'([^']+)'|([A-Za-z0-9_]+)):\s*\{", route_source, re.MULTILINE
+    )
+    routes = {quoted or bare for quoted, bare in route_matches}
+
+    source = _read_tree(dial_root / "src", "**/*.ts")
+    source += "\n" + _read_tree(dial_root / "src", "**/*.tsx")
+    api_methods = set(re.findall(r"\bapi\.([A-Za-z][A-Za-z0-9_]*)\s*\(", source))
+    socket_receives = set(re.findall(r"socket\.on\(\s*['\"]([^'\"]+)['\"]", source))
+    socket_emits = set(re.findall(r"socket\.emit\(\s*['\"]([^'\"]+)['\"]", source))
+    return {
+        "screens": screens,
+        "routes": routes,
+        "api_methods": api_methods,
+        "socket_receives": socket_receives,
+        "socket_emits": socket_emits,
+    }
+
+
+def discover_backend(backend_root: Path) -> dict[str, set[str]]:
+    api_source = _read_tree(backend_root / "api", "**/*.py")
+    source = _read_tree(backend_root, "*.py") + "\n" + api_source
+    routes = set(
+        re.findall(
+            r'API\.register_handler\(\s*APIVersion\.V1,\s*r"([^"]+)"',
+            api_source,
+            re.DOTALL,
+        )
+    )
+    socket_receives = set(re.findall(r'@sio\.on\(\s*["\']([^"\']+)["\']', source))
+    socket_emits = set(re.findall(r'\.emit\(\s*["\']([^"\']+)["\']', source))
+
+    machine_source = (backend_root / "machine.py").read_text(encoding="utf-8")
+    actions: set[str] = set()
+    for name in ("ALLOWED_BACKEND_ACTIONS", "ALLOWED_ESP_ACTIONS"):
+        match = re.search(rf"{name}\s*=\s*\[(?P<body>.*?)\]", machine_source, re.DOTALL)
+        if match:
+            actions.update(re.findall(r'["\']([^"\']+)["\']', match.group("body")))
+
+    emulation_source = (
+        backend_root / "esp_serial/connection/emulation_data.py"
+    ).read_text(encoding="utf-8")
+    emulator_source = (
+        backend_root / "esp_serial/connection/emulator_serial_connection.py"
+    ).read_text(encoding="utf-8")
+    scenarios = {"idle"}
+    if "ESPRESSO_DATA" in emulation_source and 'b"action,start"' in emulator_source:
+        scenarios.add("espresso")
+    if "HOME_DATA" in emulation_source and 'b"action,home"' in emulator_source:
+        scenarios.add("home")
+    if "PURGE_DATA" in emulation_source and 'b"action,purge"' in emulator_source:
+        scenarios.add("purge")
+
+    return {
+        "api_routes": routes,
+        "socket_receives": socket_receives,
+        "socket_emits": socket_emits,
+        "allowed_actions": actions,
+        "emulation_scenarios": scenarios,
+    }
+
+
+def _map_keys(source: str, map_name: str) -> set[str]:
+    block = re.search(rf"{map_name}\s*\{{(?P<body>.*?)\}};", source, re.DOTALL)
+    if not block:
+        raise ValueError(f"Could not find firmware map {map_name}")
+    return set(re.findall(r'\{"([^"]+)"', block.group("body")))
+
+
+def discover_firmware(firmware_root: Path) -> dict[str, set[str]]:
+    uart_source = (firmware_root / "lib/FikaUart/FikaUart.cpp").read_text(
+        encoding="utf-8"
+    )
+    firmware_source = _read_tree(firmware_root / "lib", "**/*.cpp")
+    firmware_source += "\n" + _read_tree(firmware_root / "lib", "**/*.h")
+    firmware_source += "\n" + _read_tree(firmware_root / "src", "**/*.cpp")
+    firmware_source += "\n" + _read_tree(firmware_root / "include", "**/*.h")
+    outbound_messages: set[str] = set()
+    for pattern in (
+        r'std::cout[ \t]*<<[ \t]*"([A-Za-z_]+),',
+        r'\bbuffer[ \t]*<<[ \t]*"([A-Za-z_]+),',
+        r'\bString[ \t]+\w+[ \t]*=[ \t]*"([A-Za-z_]+),',
+        r'\buart_print\([ \t]*"([A-Za-z_]+),',
+        r'\bsprintf\([^,]+,[ \t]*"([A-Za-z_]+),',
+        r'\bmessage[ \t]*<<[ \t]*"([A-Za-z_]+),',
+    ):
+        outbound_messages.update(re.findall(pattern, firmware_source))
+    # Lower-case fragments such as "none,..." are continuations of a Data
+    # record, not independent messages. nvs_response is the one lower-case
+    # top-level protocol prefix in the current UART contract.
+    outbound_messages = {
+        message
+        for message in outbound_messages
+        if message[0].isupper() or message == "nvs_response"
+    }
+    return {
+        "uart_incoming_keys": _map_keys(uart_source, "incomming_keys_map"),
+        "uart_actions": _map_keys(uart_source, "command_action_map"),
+        "uart_outbound_messages": outbound_messages,
+    }
+
+
+def discover_machine(machine_root: Path) -> dict[str, set[str]]:
+    config_source = (machine_root / "config.sh").read_text(encoding="utf-8")
+    component_sources = set(
+        re.findall(
+            r"^(?:readonly\s+|export\s+)?\s*([A-Z0-9_]+)_GIT=",
+            config_source,
+            re.MULTILINE,
+        )
+    )
+    return {"component_sources": component_sources}
+
+
+def validate_sources(
+    manifest: dict,
+    machine_root: Path,
+    dial_root: Path,
+    backend_root: Path,
+    firmware_root: Path,
+) -> list[str]:
+    errors: list[str] = []
+    dial = discover_dial(dial_root)
+    expected_screens = flatten_screen_groups(manifest)
+    errors += _compare("Dial ScreenType", dial["screens"], expected_screens)
+    errors += _compare("Dial routes", dial["routes"], expected_screens)
+    errors += _compare(
+        "Dial API methods", dial["api_methods"], manifest["dial"]["api_methods"]
+    )
+    errors += _compare(
+        "Dial Socket.IO receives",
+        dial["socket_receives"],
+        manifest["dial"]["socket_receives"],
+    )
+    errors += _compare(
+        "Dial Socket.IO emits", dial["socket_emits"], manifest["dial"]["socket_emits"]
+    )
+
+    backend = discover_backend(backend_root)
+    for key, label in (
+        ("api_routes", "Backend API routes"),
+        ("socket_receives", "Backend Socket.IO receives"),
+        ("socket_emits", "Backend Socket.IO emits"),
+        ("allowed_actions", "Backend allowed actions"),
+        ("emulation_scenarios", "Backend emulation scenarios"),
+    ):
+        errors += _compare(label, backend[key], manifest["backend"][key])
+
+    firmware = discover_firmware(firmware_root)
+    for key, label in (
+        ("uart_incoming_keys", "Firmware UART incoming keys"),
+        ("uart_actions", "Firmware UART actions"),
+        ("uart_outbound_messages", "Firmware UART outbound messages"),
+    ):
+        errors += _compare(label, firmware[key], manifest["firmware"][key])
+
+    machine = discover_machine(machine_root)
+    errors += _compare(
+        "Machine component sources",
+        machine["component_sources"],
+        manifest["image"]["component_sources"],
+    )
+
+    service_roots = [
+        machine_root / "system-services",
+        machine_root / "config/usr/lib/systemd/system",
+    ]
+    for service in manifest["image"]["required_services"]:
+        if not any((root / service).is_file() for root in service_roots):
+            errors.append(f"Machine required service is missing: {service}")
+
+    nginx_source = (
+        machine_root / "config/etc/nginx/sites-available/default"
+    ).read_text(encoding="utf-8")
+    for contract in manifest["image"]["nginx_contracts"]:
+        if contract not in nginx_source:
+            errors.append(f"Machine Nginx contract is missing: {contract}")
+
+    for channel in ("beta", "stable"):
+        if not (machine_root / f"images/{channel}.versions.sh").is_file():
+            errors.append(f"Machine channel manifest is missing: {channel}")
+    if "nightly" not in manifest["image"]["channels"]:
+        errors.append("Machine inventory must include nightly config.sh defaults")
+
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--machine", type=Path, default=REPO_ROOT)
+    parser.add_argument("--dial", type=Path)
+    parser.add_argument("--backend", type=Path)
+    parser.add_argument("--firmware", type=Path)
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="Validate only manifest structure; component paths are not required.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    errors = validate_manifest(manifest)
+
+    if not args.self_check:
+        missing_args = [
+            name
+            for name in ("dial", "backend", "firmware")
+            if getattr(args, name) is None
+        ]
+        if missing_args:
+            errors.append(
+                "Full validation requires component paths: " + ", ".join(missing_args)
+            )
+        else:
+            errors += validate_sources(
+                manifest,
+                args.machine.resolve(),
+                args.dial.resolve(),
+                args.backend.resolve(),
+                args.firmware.resolve(),
+            )
+
+    if errors:
+        print("E2E contract inventory validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    screens = flatten_screen_groups(manifest)
+    print(
+        "E2E contract inventory is valid: "
+        f"{len(screens)} Dial screens, "
+        f"{len(manifest['backend']['api_routes'])} backend routes, "
+        f"{len(manifest['firmware']['uart_actions'])} firmware actions, "
+        f"{len(manifest['image']['component_sources'])} image component sources, "
+        f"{len(manifest['journeys'])} planned journeys."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_e2e_contract.py
+++ b/tests/test_e2e_contract.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "validate_e2e_contract.py"
+SPEC = importlib.util.spec_from_file_location("validate_e2e_contract", SCRIPT_PATH)
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class E2EContractManifestTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.manifest = VALIDATOR.load_manifest()
+
+    def test_manifest_is_internally_consistent(self):
+        self.assertEqual(VALIDATOR.validate_manifest(self.manifest), [])
+
+    def test_every_screen_is_owned_by_exactly_one_group(self):
+        screens = VALIDATOR.flatten_screen_groups(self.manifest)
+        self.assertEqual(len(screens), len(set(screens)))
+
+    def test_every_journey_has_a_test_tier_and_explicit_status(self):
+        for journey in self.manifest["journeys"]:
+            with self.subTest(journey=journey["id"]):
+                self.assertTrue(journey["tiers"])
+                self.assertIn(journey["status"], {"planned", "implemented", "blocked"})
+
+    def test_full_route_reachability_is_a_p0_target(self):
+        journey = next(
+            item
+            for item in self.manifest["journeys"]
+            if item["id"] == "dial-all-routes-reachable"
+        )
+        self.assertEqual(journey["priority"], "P0")
+        self.assertEqual(journey["screen_groups"], ["*"])
+
+    def test_known_contract_gaps_have_follow_up_actions(self):
+        for gap in self.manifest["known_gaps"]:
+            with self.subTest(gap=gap["id"]):
+                self.assertTrue(gap["evidence"])
+                self.assertTrue(gap["next_step"])
+
+    def test_set_comparison_detects_contract_drift(self):
+        errors = VALIDATOR._compare("example", {"kept", "new"}, {"kept", "removed"})
+        self.assertEqual(
+            errors,
+            [
+                "example: missing from source: ['removed']",
+                "example: not inventoried: ['new']",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a versioned cross-repository E2E contract covering Dial screens and API usage, backend routes and emulation support, firmware UART actions, and machine-image integration surfaces.
- Add a source-drift validator, unit coverage, and a pull-request/scheduled workflow that validates the contract against current `nightly` component sources.
- Document 10 planned simulated, rootfs, and hardware-in-the-loop journeys, including known gaps and ownership boundaries.
- This milestone defines and enforces the coverage contract; it does not execute the product journeys yet.

## Validation
- E2E contract validator against clean `nightly` checkouts of `meticulous-dial`, `meticulous-backend`, and `EspressoFirmware`
- `python -m unittest discover -s tests -v` (23 tests passed)
- `python -m black --check scripts/validate_e2e_contract.py tests/test_e2e_contract.py`
- Python compilation, JSON parsing, workflow YAML parsing, and `git diff --check`