### PR TITLE
SW-111: Introduce an ESP32-owned UUID for Hawkbit Controller ID migration

### DIFF
--- a/.github/workflows/validate-e2e-contract.yml
+++ b/.github/workflows/validate-e2e-contract.yml
@@ -8,9 +8,11 @@ on:
       - "e2e/contracts/**"
       - "scripts/validate_e2e_contract.py"
       - "tests/test_e2e_contract.py"
+      - "tests/test_hawkbit_device_identity.sh"
       - "config.sh"
       - "images/*.versions.sh"
       - "system-services/**"
+      - "config/etc/hawkbit/**"
       - "config/etc/nginx/sites-available/default"
   push:
     branches:
@@ -21,9 +23,11 @@ on:
       - "e2e/contracts/**"
       - "scripts/validate_e2e_contract.py"
       - "tests/test_e2e_contract.py"
+      - "tests/test_hawkbit_device_identity.sh"
       - "config.sh"
       - "images/*.versions.sh"
       - "system-services/**"
+      - "config/etc/hawkbit/**"
       - "config/etc/nginx/sites-available/default"
   schedule:
     - cron: "23 5 * * *"
@@ -73,6 +77,14 @@ jobs:
       - name: Validate contract structure
         working-directory: meticulous-machine
         run: python -m unittest discover -s tests -p 'test_e2e_contract.py' -v
+
+      - name: Validate Hawkbit device identity
+        working-directory: meticulous-machine
+        run: |
+          bash -n config/etc/hawkbit/create_config.sh
+          bash -n config/etc/hawkbit/device_identity.sh
+          bash -n tests/test_hawkbit_device_identity.sh
+          bash tests/test_hawkbit_device_identity.sh
 
       - name: Validate contract against source
         working-directory: meticulous-machine

--- a/config/etc/hawkbit/config.conf.template
+++ b/config/etc/hawkbit/config.conf.template
@@ -28,6 +28,7 @@
   som                       = __SOM__
   installed_version         = __INSTALLED_VERSION__
   backup_version            = __BACKUP_VERSION__
+  next_controller_id        = __NEXT_CONTROLLER_ID__
   memory                    = __MEMORY__
   uboot_active_version      = __UBOOT_ACTIVE_REV__
   uboot_active_slot         = __UBOOT_ACTIVE__

--- a/config/etc/hawkbit/create_config.sh
+++ b/config/etc/hawkbit/create_config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source "${HAWKBIT_DEVICE_IDENTITY_LIB:-/etc/hawkbit/device_identity.sh}"
+source /etc/hawkbit/device_identity.sh
 
 get_somrev() {
         # Get the raw output

--- a/config/etc/hawkbit/create_config.sh
+++ b/config/etc/hawkbit/create_config.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "${HAWKBIT_DEVICE_IDENTITY_LIB:-/etc/hawkbit/device_identity.sh}"
+
 get_somrev() {
         # Get the raw output
         raw_output=$(i2cget -f -y 0x0 0x52 0x1e)
@@ -155,6 +157,7 @@ fi
 
 installed_version=$(get_installed_sw_version)
 backup_version=$(get_backup_sw_version)
+device_uuid=$(get_cached_device_uuid) || device_uuid="UNKNOWN"
 
 memory=$(cat /proc/meminfo | grep MemTotal | grep "[0-9]* [a-zA-Z]B" -o)
 som=$(get_somrev)
@@ -188,6 +191,7 @@ sed -i "s/__SOM__/${som}/" /etc/hawkbit/config.conf
 sed -i "s/__MEMORY__/${memory}/" /etc/hawkbit/config.conf
 sed -i "s/__INSTALLED_VERSION__/${installed_version}/" /etc/hawkbit/config.conf
 sed -i "s/__BACKUP_VERSION__/${backup_version}/" /etc/hawkbit/config.conf
+sed -i "s/__NEXT_CONTROLLER_ID__/${device_uuid}/" /etc/hawkbit/config.conf
 
 sed -i "s/__UBOOT_DISK_REV__/${uboot_disk_rev}/" /etc/hawkbit/config.conf
 sed -i "s/__UBOOT_BOOT0_REV__/${uboot_boot0_rev}/" /etc/hawkbit/config.conf

--- a/config/etc/hawkbit/device_identity.sh
+++ b/config/etc/hawkbit/device_identity.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+HAWKBIT_DEVICE_IDENTITY_DIR="${HAWKBIT_DEVICE_IDENTITY_DIR:-/meticulous-user/.device-identity}"
+HAWKBIT_DEVICE_UUID_FILE="${HAWKBIT_DEVICE_UUID_FILE:-${HAWKBIT_DEVICE_IDENTITY_DIR}/device-uuid}"
+
+is_valid_uuid_v4() {
+  local uuid="$1"
+
+  [[ "$uuid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
+}
+
+get_cached_device_uuid() {
+  local cached_uuid=""
+
+  if [ ! -r "$HAWKBIT_DEVICE_UUID_FILE" ]; then
+    echo "ESP32 device UUID cache is not available" >&2
+    return 1
+  fi
+
+  IFS= read -r cached_uuid < "$HAWKBIT_DEVICE_UUID_FILE"
+  if ! is_valid_uuid_v4 "$cached_uuid"; then
+    echo "ESP32 device UUID cache is invalid" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$cached_uuid"
+}

--- a/config/etc/hawkbit/device_identity.sh
+++ b/config/etc/hawkbit/device_identity.sh
@@ -11,13 +11,20 @@ is_valid_uuid_v4() {
 
 get_cached_device_uuid() {
   local cached_uuid=""
+  local cached_lines=()
 
   if [ ! -r "$HAWKBIT_DEVICE_UUID_FILE" ]; then
     echo "ESP32 device UUID cache is not available" >&2
     return 1
   fi
 
-  IFS= read -r cached_uuid < "$HAWKBIT_DEVICE_UUID_FILE"
+  mapfile -t cached_lines < "$HAWKBIT_DEVICE_UUID_FILE"
+  if [ "${#cached_lines[@]}" -ne 1 ]; then
+    echo "ESP32 device UUID cache is invalid" >&2
+    return 1
+  fi
+
+  cached_uuid="${cached_lines[0]}"
   if ! is_valid_uuid_v4 "$cached_uuid"; then
     echo "ESP32 device UUID cache is invalid" >&2
     return 1

--- a/docs/hawkbit-device-identity.md
+++ b/docs/hawkbit-device-identity.md
@@ -18,8 +18,9 @@ persists the value in NVS, then reports it back through ESPInfo.
 After that assignment, the ESP32 NVS value is the source of truth. The backend
 updates this VAR-SOM cache only from a valid UUID confirmed through ESPInfo. If
 the confirmed ESP32 value differs, it atomically overwrites the cache and
-restarts the Hawkbit updater so its generated configuration uses the current
-value.
+restarts the Hawkbit updater so its generated local configuration uses the
+current value. Restarting the updater does not itself make Hawkbit request or
+replace the target's stored device attributes.
 
 The hidden cache directory is on the shared user partition. It therefore
 survives RAUC slot updates and rollbacks. The current backend factory reset
@@ -53,6 +54,14 @@ This change depends on coordinated firmware and backend support:
   for ESPInfo confirmation, and then synchronizes the VAR-SOM cache.
 
 The updater sends device attributes only when Hawkbit includes the
-`configData` link in its DDI response. After deploying this image, request
-attributes for the existing targets by setting `requestAttributes` to `true`
-through the Hawkbit Management API before auditing `next_controller_id`.
+`configData` link in its DDI response. Hawkbit controls that link through the
+target's server-side `requestAttributes` flag; restarting the updater cannot
+set it.
+
+After deploying this image, set `requestAttributes` to `true` through the
+Hawkbit Management API for every target before auditing `next_controller_id`.
+Repeat that refresh for targets whose first upload reported `UNKNOWN`, including
+newly provisioned machines that contacted Hawkbit before ESP32 enrollment
+completed. A cache update and updater restart alone do not replace a previously
+stored `UNKNOWN` attribute. Do not begin the fleet uniqueness and completeness
+audit until the refreshed attributes have been received.

--- a/docs/hawkbit-device-identity.md
+++ b/docs/hawkbit-device-identity.md
@@ -1,0 +1,58 @@
+# Hawkbit device identity
+
+The Hawkbit updater continues to use the existing hostname-based
+`target_name`. During the first migration phase, each machine also publishes
+the ESP32-owned UUIDv4 as the `next_controller_id` device attribute.
+
+The UUID is stored at:
+
+```text
+/meticulous-user/.device-identity/device-uuid
+```
+
+The VAR-SOM generates the initial UUIDv4 using the Linux OS entropy source only
+when compatible firmware reports that the ESP32 has no valid UUID. It sends the
+candidate through a dedicated write-once UART command. The ESP32 validates and
+persists the value in NVS, then reports it back through ESPInfo.
+
+After that assignment, the ESP32 NVS value is the source of truth. The backend
+updates this VAR-SOM cache only from a valid UUID confirmed through ESPInfo. If
+the confirmed ESP32 value differs, it atomically overwrites the cache and
+restarts the Hawkbit updater so its generated configuration uses the current
+value.
+
+The hidden cache directory is on the shared user partition. It therefore
+survives RAUC slot updates and rollbacks. The current backend factory reset
+removes `/meticulous-user/*`; shell globbing does not include hidden entries,
+so the cache also survives that reset. The directory and file use modes `0700`
+and `0600`. The UUID is an opaque identifier, not a credential.
+
+The updater never generates or repairs device identity. If the cache is
+missing or invalid, it reports `next_controller_id` as `UNKNOWN` without
+changing the active Hawkbit target.
+
+The backend never copies a previously cached VAR-SOM UUID into an empty or
+corrupt ESP32. That state may indicate that the ESP32 was replaced. Instead, it
+generates a new candidate, assigns it write-once, waits for the ESP32 to confirm
+it, and then replaces the VAR-SOM cache. A valid UUID already stored on the
+ESP32 always wins.
+
+Before switching `target_name`, fleet validation must confirm:
+
+- every online target reports a valid UUIDv4;
+- no two targets report the same UUID;
+- the UUID remains unchanged across updater restarts, OTA rollback, and factory
+  reset;
+- no target reports `UNKNOWN`.
+
+This change depends on coordinated firmware and backend support:
+
+- EspressoFirmware exposes UUID protocol support in ESPInfo and accepts a
+  dedicated write-once assignment only while no valid UUID exists in NVS.
+- meticulous-backend generates the initial UUIDv4, sends the assignment, waits
+  for ESPInfo confirmation, and then synchronizes the VAR-SOM cache.
+
+The updater sends device attributes only when Hawkbit includes the
+`configData` link in its DDI response. After deploying this image, request
+attributes for the existing targets by setting `requestAttributes` to `true`
+through the Hawkbit Management API before auditing `next_controller_id`.

--- a/docs/testing/e2e-contract-inventory.md
+++ b/docs/testing/e2e-contract-inventory.md
@@ -37,7 +37,7 @@ The captured contract contains:
 - 57 backend API route patterns, 4 inbound Socket.IO events and 9 outbound
   Socket.IO events.
 - 4 existing backend emulation scenarios: idle, home, purge and espresso.
-- 5 firmware UART command families, 13 actions and 11 outbound message
+- 6 firmware UART command families, 13 actions and 11 outbound message
   families.
 - 19 component repositories declared by the image integrator.
 - 10 product journeys targeted for future automated execution.

--- a/e2e/contracts/coverage.json
+++ b/e2e/contracts/coverage.json
@@ -236,6 +236,7 @@
   "firmware": {
     "uart_incoming_keys": [
       "action",
+      "device_uuid",
       "hash",
       "heater_timeout",
       "json",

--- a/tests/test_hawkbit_device_identity.sh
+++ b/tests/test_hawkbit_device_identity.sh
@@ -40,6 +40,8 @@ assert_invalid_cache "123e4567-e89b-12d3-a456-426614174000\n" "non-v4"
 assert_invalid_cache "123e4567-e89b-42d3-7456-426614174000\n" "non-RFC-variant"
 assert_invalid_cache "" "empty"
 assert_invalid_cache "${first_uuid} trailing-content\n" "trailing-content"
+assert_invalid_cache "${first_uuid}\nunexpected-line\n" "multi-line"
+assert_invalid_cache "${first_uuid}\n\n" "extra-empty-line"
 
 printf '%s\n' "$second_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
 test "$(get_cached_device_uuid)" = "$second_uuid"

--- a/tests/test_hawkbit_device_identity.sh
+++ b/tests/test_hawkbit_device_identity.sh
@@ -14,6 +14,17 @@ source "${repo_root}/config/etc/hawkbit/device_identity.sh"
 first_uuid="123e4567-e89b-42d3-a456-426614174000"
 second_uuid="987e6543-e21b-45d3-b654-426614174999"
 
+assert_invalid_cache() {
+  local value="$1"
+  local description="$2"
+
+  printf '%b' "$value" > "$HAWKBIT_DEVICE_UUID_FILE"
+  if get_cached_device_uuid; then
+    echo "Expected ${description} ESP32 device UUID cache to fail" >&2
+    exit 1
+  fi
+}
+
 if get_cached_device_uuid; then
   echo "Expected a missing ESP32 device UUID cache to fail" >&2
   exit 1
@@ -23,20 +34,22 @@ mkdir -p "$HAWKBIT_DEVICE_IDENTITY_DIR"
 printf '%s\n' "$first_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
 test "$(get_cached_device_uuid)" = "$first_uuid"
 
-printf '%s\n' "invalid" > "$HAWKBIT_DEVICE_UUID_FILE"
-if get_cached_device_uuid; then
-  echo "Expected an invalid ESP32 device UUID cache to fail" >&2
-  exit 1
-fi
+assert_invalid_cache "invalid\n" "malformed"
+assert_invalid_cache "123E4567-E89B-42D3-A456-426614174000\n" "uppercase"
+assert_invalid_cache "123e4567-e89b-12d3-a456-426614174000\n" "non-v4"
+assert_invalid_cache "123e4567-e89b-42d3-7456-426614174000\n" "non-RFC-variant"
+assert_invalid_cache "" "empty"
+assert_invalid_cache "${first_uuid} trailing-content\n" "trailing-content"
 
-# The backend treats the ESP32 as the source of truth and replaces a different
-# VAR-SOM cache value with the UUID reported by the ESP32.
 printf '%s\n' "$second_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
 test "$(get_cached_device_uuid)" = "$second_uuid"
 
 mkdir -p "${test_root}/meticulous-user/config"
 printf '%s\n' "user data" > "${test_root}/meticulous-user/config/settings"
-rm -rf "${test_root}/meticulous-user/"*
+
+# Exercise the exact /bin/sh glob shape used by the current factory-reset
+# cleanup. Hidden entries must remain outside that glob.
+sh -c 'rm -rf "$1"/*' sh "${test_root}/meticulous-user"
 
 test ! -e "${test_root}/meticulous-user/config"
 test -f "$HAWKBIT_DEVICE_UUID_FILE"

--- a/tests/test_hawkbit_device_identity.sh
+++ b/tests/test_hawkbit_device_identity.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+export HAWKBIT_DEVICE_IDENTITY_DIR="${test_root}/meticulous-user/.device-identity"
+export HAWKBIT_DEVICE_UUID_FILE="${HAWKBIT_DEVICE_IDENTITY_DIR}/device-uuid"
+
+source "${repo_root}/config/etc/hawkbit/device_identity.sh"
+
+first_uuid="123e4567-e89b-42d3-a456-426614174000"
+second_uuid="987e6543-e21b-45d3-b654-426614174999"
+
+if get_cached_device_uuid; then
+  echo "Expected a missing ESP32 device UUID cache to fail" >&2
+  exit 1
+fi
+
+mkdir -p "$HAWKBIT_DEVICE_IDENTITY_DIR"
+printf '%s\n' "$first_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
+test "$(get_cached_device_uuid)" = "$first_uuid"
+
+printf '%s\n' "invalid" > "$HAWKBIT_DEVICE_UUID_FILE"
+if get_cached_device_uuid; then
+  echo "Expected an invalid ESP32 device UUID cache to fail" >&2
+  exit 1
+fi
+
+# The backend treats the ESP32 as the source of truth and replaces a different
+# VAR-SOM cache value with the UUID reported by the ESP32.
+printf '%s\n' "$second_uuid" > "$HAWKBIT_DEVICE_UUID_FILE"
+test "$(get_cached_device_uuid)" = "$second_uuid"
+
+mkdir -p "${test_root}/meticulous-user/config"
+printf '%s\n' "user data" > "${test_root}/meticulous-user/config/settings"
+rm -rf "${test_root}/meticulous-user/"*
+
+test ! -e "${test_root}/meticulous-user/config"
+test -f "$HAWKBIT_DEVICE_UUID_FILE"
+test "$(get_cached_device_uuid)" = "$second_uuid"
+
+echo "Hawkbit device identity tests passed"


### PR DESCRIPTION
<!-- linear-agent-orchestrator:pr-description:start -->
## Summary
- Reads the ESP-confirmed UUID cache and publishes it as Hawkbit `next_controller_id` while retaining the hostname-based controller ID during migration. Missing or invalid cache data publishes `UNKNOWN`.
- Integrates identity rendering with beta's serialized config writer and atomic attribute cache. A single UUID snapshot feeds both outputs, so they cannot disagree during one render.
- Updates the cross-repository contract workflow to validate beta siblings and extends the inventory for beta's Dial, backend, and firmware surfaces.

## Validation
- `pytest` — 62 passed
- `bash tests/test_hawkbit_device_identity.sh`
- `bash -n config/etc/hawkbit/create_config.sh config/etc/hawkbit/device_identity.sh tests/test_hawkbit_device_identity.sh`
- `python scripts/validate_e2e_contract.py --self-check`
- Combined beta merge-tree contract validation — 65 Dial screens, 67 backend routes, 13 firmware actions, 19 image component sources, 10 planned journeys
- `git diff --check`

The hosted cross-repository validation reads the actual beta branches, so its UUID firmware assertion becomes green after EspressoFirmware #495 reaches beta.

## Related PRs
- [meticulous-backend #389](https://github.com/MeticulousHome/meticulous-backend/pull/389)
- [EspressoFirmware #495](https://github.com/MeticulousHome/EspressoFirmware/pull/495)

Linear: [SW-111](https://linear.app/meticulous-home/issue/SW-111/introduce-an-esp32-owned-uuid-for-hawkbit-controller-id-migration)

> Draft maintained by the local agent orchestrator. Human approval and merge are required.
<!-- linear-agent-orchestrator:pr-description:end -->

