### PR TITLE
Feat/send hawkbit attributes proactively

### DIFF
--- a/config/etc/hawkbit/config.conf.template
+++ b/config/etc/hawkbit/config.conf.template
@@ -19,7 +19,6 @@
 [device]
   product                   = Meticulous-Machine
   model                     = M-1
-  update_channel            = __UPDATE_CHANNEL__
   boot_mode                 = __BOOT_MODE__
   serial                    = __SERIAL__
   boot_partition            = __BOOTED__

--- a/config/etc/hawkbit/create_config.sh
+++ b/config/etc/hawkbit/create_config.sh
@@ -1,5 +1,61 @@
 #!/bin/bash
 
+CONFIG_LOCK_FILE="/run/meticulous-hawkbit-config.lock"
+ATTRIBUTE_CACHE="/run/meticulous-hawkbit-attributes.json"
+
+# meticulous-smoke-report regenerates the config when it finds it missing, so
+# this script can run concurrently with rauc-hawkbit-updater's ExecStartPre.
+# Both writers edit /etc/hawkbit/config.conf in place; serialise them.
+exec 9>"$CONFIG_LOCK_FILE"
+if ! flock -w 120 9; then
+  echo "WARNING: timed out waiting for ${CONFIG_LOCK_FILE}, continuing unlocked"
+fi
+
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/\t/\\t/g' | tr -d '\n\r'
+}
+
+emit_attribute() {
+  if [ "${ATTR_FIRST}" -eq 1 ]; then
+    ATTR_FIRST=0
+  else
+    printf ',\n' >> "$ATTR_TMP"
+  fi
+  printf '  "%s": "%s"' "$(json_escape "$1")" "$(json_escape "$2")" >> "$ATTR_TMP"
+}
+
+# Cache the boot-invariant device attributes so meticulous-smoke-report can
+# publish them without re-deriving anything. update_channel is deliberately
+# absent: it is the one attribute that changes at runtime, so the publisher
+# reads /etc/hawkbit/channel directly instead of trusting a boot-time copy.
+write_attribute_cache() {
+  ATTR_TMP="$(mktemp "${ATTRIBUTE_CACHE}.XXXXXX")" || return 1
+  ATTR_FIRST=1
+
+  printf '{\n' > "$ATTR_TMP"
+  emit_attribute "product"              "Meticulous-Machine"
+  emit_attribute "model"                "M-1"
+  emit_attribute "boot_mode"            "${boot_mode}"
+  emit_attribute "serial"               "${serial}"
+  emit_attribute "boot_partition"       "${boot_partition}"
+  emit_attribute "build_date"           "${build_date}"
+  emit_attribute "build_channel"        "${build_channel}"
+  emit_attribute "som"                  "${som}"
+  emit_attribute "installed_version"    "${installed_version}"
+  emit_attribute "backup_version"       "${backup_version}"
+  emit_attribute "memory"               "${memory}"
+  emit_attribute "uboot_active_version" "${uboot_active_ref}"
+  emit_attribute "uboot_active_slot"    "${uboot_active}"
+  emit_attribute "uboot_disk_version"   "${uboot_disk_rev}"
+  emit_attribute "uboot_boot0_version"  "${uboot_boot0_rev}"
+  emit_attribute "uboot_boot1_version"  "${uboot_boot1_rev}"
+  printf '\n}\n' >> "$ATTR_TMP"
+
+  # Published atomically: a killed generator must leave no half-written cache.
+  chmod 0644 "$ATTR_TMP"
+  mv -f "$ATTR_TMP" "$ATTRIBUTE_CACHE"
+}
+
 get_somrev() {
         # Get the raw output
         raw_output=$(i2cget -f -y 0x0 0x52 0x1e)
@@ -179,7 +235,6 @@ fi
 
 sed -i "s/__TARGET_NAME__/${identifier}/" /etc/hawkbit/config.conf
 sed -i "s/__BOOT_MODE__/${boot_mode}/" /etc/hawkbit/config.conf
-sed -i "s/__UPDATE_CHANNEL__/${update_channel}/" /etc/hawkbit/config.conf
 sed -i "s/__SERIAL__/${serial}/" /etc/hawkbit/config.conf
 sed -i "s/__BOOTED__/${boot_partition}/" /etc/hawkbit/config.conf
 sed -i "s/__BUILD_DATE__/${build_date}/" /etc/hawkbit/config.conf
@@ -194,3 +249,5 @@ sed -i "s/__UBOOT_BOOT0_REV__/${uboot_boot0_rev}/" /etc/hawkbit/config.conf
 sed -i "s/__UBOOT_BOOT1_REV__/${uboot_boot1_rev}/" /etc/hawkbit/config.conf
 sed -i "s|__UBOOT_ACTIVE__|${uboot_active}|" /etc/hawkbit/config.conf
 sed -i "s/__UBOOT_ACTIVE_REV__/${uboot_active_ref}/" /etc/hawkbit/config.conf
+
+write_attribute_cache

--- a/scripts/meticulous-smoke-report
+++ b/scripts/meticulous-smoke-report
@@ -168,7 +168,11 @@ def make_shot_attributes():
     try:
         backend_status = read_backend_status()
     except Exception as exc:
-        backend_status = {"error": str(exc)}
+        # These attributes are merged, not replaced. Falling back to "false"
+        # here would clobber a real completion every time the backend happens to
+        # be unreachable, which the hourly resync would then repeat forever.
+        print(f"Skipping post-update shot attributes: {exc}", file=sys.stderr)
+        return {}
 
     completed = backend_status.get("post_update_shot_completed") is True
     return {

--- a/scripts/meticulous-smoke-report
+++ b/scripts/meticulous-smoke-report
@@ -14,6 +14,8 @@ from pathlib import Path
 
 HAWKBIT_CONFIG = Path("/etc/hawkbit/config.conf")
 HAWKBIT_CONFIG_GENERATOR = Path("/etc/hawkbit/create_config.sh")
+HAWKBIT_ATTRIBUTE_CACHE = Path("/run/meticulous-hawkbit-attributes.json")
+HAWKBIT_CHANNEL_FILE = Path("/etc/hawkbit/channel")
 BACKEND_URL = "http://127.0.0.1:8080/api/v1/smoke-validation"
 MACHINE_INFO_URL = "http://127.0.0.1:8080/api/v1/machine"
 MACHINE_CONFIG_FILE = Path("/meticulous-user/config/config.yml")
@@ -27,6 +29,12 @@ DEFAULT_DIAL_SENTRY_DSN = (
     "o4506723336060928.ingest.us.sentry.io/4511430165921792"
 )
 DIAL_CHECKS = ("dial_service", "dial_ready", "dial_home_ready")
+
+# Marks a machine as reporting its own attributes. The server-side
+# hawkbit-attribute-refresher is retired per channel once every online
+# target in that channel carries this attribute, so it must be published
+# on every run, even when deriving the rest of the set fails.
+ATTRIBUTE_REPORTER = "push-v1"
 
 
 def now():
@@ -164,6 +172,35 @@ def make_boot_attributes(timeout):
     return attributes
 
 
+def make_device_attributes():
+    """Device attributes previously published only by rauc-hawkbit-updater.
+
+    Everything except update_channel is fixed for the lifetime of a boot, so it
+    is derived once by create_config.sh and cached. update_channel is read live:
+    the backend rewrites it whenever the user switches channel, and a boot-time
+    copy would be stale exactly when it matters.
+    """
+    attributes = {"attribute_reporter": ATTRIBUTE_REPORTER}
+
+    try:
+        cached = json.loads(HAWKBIT_ATTRIBUTE_CACHE.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"Failed to read {HAWKBIT_ATTRIBUTE_CACHE}: {exc}", file=sys.stderr)
+        cached = {}
+
+    for key, value in cached.items():
+        # Attributes are merged server-side, so an empty value would overwrite a
+        # good one. Omitting the key leaves whatever hawkBit already holds.
+        if isinstance(value, str) and value:
+            attributes[key] = value
+
+    channel = read_text(HAWKBIT_CHANNEL_FILE, default="")
+    if channel:
+        attributes["update_channel"] = channel
+
+    return attributes
+
+
 def make_shot_attributes():
     try:
         backend_status = read_backend_status()
@@ -189,10 +226,14 @@ def make_shot_attributes():
 
 
 def ensure_hawkbit_config():
-    if HAWKBIT_CONFIG.exists():
+    # The cache lives on tmpfs and is normally written by rauc-hawkbit-updater's
+    # ExecStartPre, so it is absent whenever that unit failed or is masked while
+    # config.conf survives from an earlier boot. The generator takes a lock, so
+    # racing the updater is safe.
+    if HAWKBIT_CONFIG.exists() and HAWKBIT_ATTRIBUTE_CACHE.exists():
         return
     if HAWKBIT_CONFIG_GENERATOR.exists():
-        run(["bash", str(HAWKBIT_CONFIG_GENERATOR)], timeout=30)
+        run(["bash", str(HAWKBIT_CONFIG_GENERATOR)], timeout=60)
 
 
 def load_hawkbit_config():
@@ -345,12 +386,21 @@ def main():
         action="store_true",
         help="publish persisted post-update shot state without waiting for boot checks",
     )
+    parser.add_argument(
+        "--attributes",
+        action="store_true",
+        help="publish device attributes without waiting for boot checks",
+    )
     parser.add_argument("--timeout", type=int, default=180)
     args = parser.parse_args()
 
     attributes = {}
-    if args.boot or not args.shot:
+    if args.boot or not (args.shot or args.attributes):
         attributes.update(make_boot_attributes(args.timeout))
+    # Device attributes ride along on every publish: each one is a full
+    # synchronisation, so a machine that reaches hawkBit at all reports a
+    # complete, current set.
+    attributes.update(make_device_attributes())
     attributes.update(make_shot_attributes())
 
     try:

--- a/system-services/meticulous-hawkbit-attributes.service
+++ b/system-services/meticulous-hawkbit-attributes.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Publish Meticulous hawkBit device attributes
+Documentation=https://linear.app/meticulous/issue/SW-114
+ConditionHost=meticulous*
+After=network-online.target rauc-hawkbit-updater.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/meticulous-venv/bin/python3 /usr/local/bin/meticulous-smoke-report --attributes
+TimeoutStartSec=4min
+User=root
+
+# Deliberately no OnFailure=crash-reporter@.service: this unit runs hourly on
+# every machine, and a transient network failure is not a crash.
+
+[Install]
+WantedBy=multi-user.target

--- a/system-services/meticulous-hawkbit-attributes.timer
+++ b/system-services/meticulous-hawkbit-attributes.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Hourly hawkBit attribute resynchronisation
+Documentation=https://linear.app/meticulous/issue/SW-114
+ConditionHost=meticulous*
+
+[Timer]
+Unit=meticulous-hawkbit-attributes.service
+# Monotonic rather than OnCalendar: the fleet is already spread by boot time,
+# so machines do not all report on the hour.
+OnBootSec=15min
+OnUnitActiveSec=1h
+RandomizedDelaySec=10min
+AccuracySec=1min
+
+[Install]
+WantedBy=timers.target

--- a/system-services/meticulous-hawkbit-channel.path
+++ b/system-services/meticulous-hawkbit-channel.path
@@ -1,0 +1,14 @@
+[Unit]
+Description=Republish hawkBit attributes when the update channel changes
+Documentation=https://linear.app/meticulous/issue/SW-114
+ConditionHost=meticulous*
+
+[Path]
+# The backend rewrites this file when the user switches update channel. It is
+# the only hawkBit attribute that changes while the machine is running, so
+# watching it replaces polling for attribute changes entirely.
+PathChanged=/etc/hawkbit/channel
+Unit=meticulous-hawkbit-attributes.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Move the responsibility of reporting the machine's attributes to hawkbit from the server to the machine, this will free some bandwidth on the server side as it currently relies on an external service to ask it to keep the attributes updated.

Most of the attributes previously saved in the config.conf file are kept there with the exception of the update_channel attribute. This so the file only keeps attributes that stay fixed between machine boots.

The create_config.sh executable is still in charge to fetch the attribute values and set them in the config.conf file but now it also saves them in a tmp cache file so they can be accesses and easily loaded by the `meticulous-smoke-report`. The update_channel is directly read from the file `/etc/hawkbit/channel` when the script executes.

To keep the `update_channel` attribute at hawkbit in sync we added a systemd path unit to monitor the `/etc/hawkbit/channel` file, when the file changes, it triggers the execution of the `meticulous-smoke-report` script. A systemd timer is also included to do an hourly sync with hawkbit in order to update possible stale data