### PR TITLE
Add one-command SGS RF test runner

### DIFF
--- a/make-rootfs.sh
+++ b/make-rootfs.sh
@@ -52,6 +52,17 @@ function install_lab_certification_tools() {
         exit 1
     fi
 
+    lab_runner="scripts/met-sgs-rf-test"
+    private_lab_runner="${LAB_CERTIFICATION_TOOLS_SRC_DIR}/sgs/met-sgs-rf-test"
+    if [ ! -f "${private_lab_runner}" ]; then
+        echo "The private lab tools checkout is missing ${private_lab_runner}."
+        exit 1
+    fi
+    if ! cmp -s "${lab_runner}" "${private_lab_runner}"; then
+        echo "The SGS RF test runner differs between meticulous-machine and lab-certification-tools."
+        exit 1
+    fi
+
     target_dir="${ROOTFS_DIR}/opt/meticulous-lab-tools"
     mkdir -p "${target_dir}"
     cp -Rv "${LAB_CERTIFICATION_TOOLS_SRC_DIR}/sgs" "${target_dir}/"

--- a/scripts/met-sgs-rf-test
+++ b/scripts/met-sgs-rf-test
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly tool_dir="${MET_SGS_RF_TOOL_DIR:-/opt/meticulous-lab-tools/sgs/Murata_NXP_RF_Test_Tool_1.29}"
+readonly tool_script="${tool_dir}/Murata_NXP_RF_Test_Tool.py"
+readonly wifi_interface="${MET_SGS_RF_WIFI_INTERFACE:-wlan0}"
+
+readonly services=(
+    NetworkManager.service
+    wpa_supplicant.service
+    meticulous-backend.service
+    meticulous-watcher.service
+    rauc-hawkbit-updater.service
+)
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+step() {
+    printf '\n== %s ==\n' "$*"
+}
+
+if [ "${EUID}" -ne 0 ]; then
+    fail "Run this command as root."
+fi
+
+[ -r "${tool_script}" ] || fail "Murata RF Test Tool v1.29 was not found at ${tool_script}."
+command -v python3 >/dev/null 2>&1 || fail "python3 is not installed."
+command -v systemctl >/dev/null 2>&1 || fail "systemctl is not available."
+command -v ip >/dev/null 2>&1 || fail "The ip command is not available."
+
+step "Preparing the machine for conducted RF testing"
+printf 'This stops normal Wi-Fi management. Run it from the FTDI serial console, not over SSH.\n'
+
+for service in "${services[@]}"; do
+    printf 'Stopping %s... ' "${service}"
+    if systemctl stop "${service}" 2>/dev/null; then
+        printf 'done\n'
+    else
+        printf 'not running or not installed\n'
+    fi
+done
+
+if command -v rfkill >/dev/null 2>&1; then
+    printf 'Unblocking the Wi-Fi radio... '
+    if rfkill unblock wifi 2>/dev/null; then
+        printf 'done\n'
+    else
+        printf 'not required\n'
+    fi
+fi
+
+ip link show "${wifi_interface}" >/dev/null 2>&1 || fail "Wi-Fi interface ${wifi_interface} was not found."
+printf 'Taking %s down... ' "${wifi_interface}"
+ip link set "${wifi_interface}" down
+printf 'done\n'
+
+step "Starting Murata NXP RF Test Tool v1.29"
+printf 'Tool directory: %s\n' "${tool_dir}"
+printf 'After the test, use the tool stop/exit flow and then reboot the machine.\n\n'
+
+cd "${tool_dir}"
+set +e
+python3 "${tool_script}"
+status=$?
+set -e
+
+printf '\nMurata RF Test Tool exited with status %s.\n' "${status}"
+printf 'Reboot the machine before returning it to normal operation.\n'
+exit "${status}"

--- a/scripts/tests/met_sgs_rf_test.sh
+++ b/scripts/tests/met_sgs_rf_test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly runner="${repo_root}/scripts/met-sgs-rf-test"
+readonly temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+mkdir -p "${temp_dir}/bin" "${temp_dir}/tool"
+touch "${temp_dir}/tool/Murata_NXP_RF_Test_Tool.py"
+
+for command_name in systemctl rfkill ip python3; do
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'printf "%s %s\\n" "$(basename "$0")" "$*" >> "${MET_SGS_RF_TEST_LOG}"' \
+        'exit 0' \
+        > "${temp_dir}/bin/${command_name}"
+    chmod +x "${temp_dir}/bin/${command_name}"
+done
+
+export MET_SGS_RF_TEST_LOG="${temp_dir}/commands.log"
+export MET_SGS_RF_TOOL_DIR="${temp_dir}/tool"
+export MET_SGS_RF_WIFI_INTERFACE="test-wlan0"
+
+PATH="${temp_dir}/bin:/usr/bin:/bin" "${runner}" > "${temp_dir}/output.log"
+
+grep -Fx 'systemctl stop NetworkManager.service' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'systemctl stop wpa_supplicant.service' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'systemctl stop meticulous-backend.service' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'systemctl stop meticulous-watcher.service' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'systemctl stop rauc-hawkbit-updater.service' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'rfkill unblock wifi' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'ip link show test-wlan0' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx 'ip link set test-wlan0 down' "${MET_SGS_RF_TEST_LOG}"
+grep -Fx "python3 ${temp_dir}/tool/Murata_NXP_RF_Test_Tool.py" "${MET_SGS_RF_TEST_LOG}"
+grep -F 'Run it from the FTDI serial console, not over SSH.' "${temp_dir}/output.log"
+grep -F 'Reboot the machine before returning it to normal operation.' "${temp_dir}/output.log"
+
+printf 'met-sgs-rf-test integration test passed.\n'


### PR DESCRIPTION
## Summary
- Add `met-sgs-rf-test` so SGS operators can prepare Wi-Fi and launch Murata v1.29 with one FTDI command.
- Fail lab-image assembly if the runner differs from the copy in the private lab-tools repository.
- Add a mocked integration test covering service stops, radio preparation, tool launch, and the reboot reminder.

## Validation
- `bash -n scripts/met-sgs-rf-test scripts/tests/met_sgs_rf_test.sh`
- `bash scripts/tests/met_sgs_rf_test.sh`
- SHA-256 comparison confirms the machine and private-repository runners are identical.