### PR TITLE
Fix lab image Git authentication

### DIFF
--- a/.github/workflows/build-image-channel.yml
+++ b/.github/workflows/build-image-channel.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Set up Git authentication
         run: |
-          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}:@github.com/".insteadOf "git@github.com:"
 
       - name: Checkout all component sources
         run: |
@@ -132,7 +132,7 @@ jobs:
 
       - name: Set up Git authentication
         run: |
-          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}:@github.com/".insteadOf "git@github.com:"
 
       - name: Clone lab certification tools
         if: ${{ inputs.image == 'lab_certification' }}
@@ -288,7 +288,7 @@ jobs:
 
       - name: Set up Git authentication
         run: |
-          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}:@github.com/".insteadOf "git@github.com:"
 
       - name: Clone private repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-nightly-image.yml
+++ b/.github/workflows/build-nightly-image.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set up Git authentication
         run: |
-          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}@github.com/".insteadOf "git@github.com:"
+          git config --global url."https://${{ secrets.GH_REPO_WORKFLOW }}:@github.com/".insteadOf "git@github.com:"
 
       - name: Download version-info artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- pass the repository token as an HTTPS credential with an explicit empty password
- apply the same authentication form to lab image source checkout, rootfs, RAUC, and component-tagging steps

## Validation
- git diff --check`n- confirmed every Git authentication rewrite used by the lab image workflow now matches the working form already present in the component workflow