### PR TITLE
Fix/validate slot before automatic fallback

### DIFF
--- a/docs/rear-button-boot-partition-switch.md
+++ b/docs/rear-button-boot-partition-switch.md
@@ -34,6 +34,23 @@ first boot after upgrading an older environment, it infers the running slot from
 the first entry in `BOOT_ORDER` that still has attempts. This prevents an
 exhausted former primary from being mistaken for the currently running slot.
 
+## Automatic slot selection
+
+The same kernel and device-tree checks guard the normal selector that runs on
+every boot. A slot whose `BOOT_<slot>_LEFT` counter is above zero is only a
+candidate; before an attempt is spent on it, U-Boot must load and decompress its
+kernel and load the device tree for the installed SOM revision. A candidate
+that fails any check is skipped with a `Slot <slot> skipped:` message and its
+counter is left untouched, and the selector continues with the next entry in
+`BOOT_ORDER`.
+
+This closes the factory-fresh failure where slot B is formatted but empty: once
+slot A exhausts its attempts, the old selector committed to slot B purely on
+its counter and the machine stopped on a black screen. Now slot B is skipped,
+no slot remains, both counters reset to three, and the next start boots slot A
+again. The cost is one extra kernel load and decompression on every boot before
+the authoritative `loadimage`.
+
 ## Hardware and release coupling
 
 On I2C Expansion Board Rev E, SW1 drives `SOM_INTn` low through J4. The main board

--- a/rauc-config/u-boot.cmd
+++ b/rauc-config/u-boot.cmd
@@ -80,28 +80,54 @@ if test "x${rauc_switch_requested}" = "x1"; then
 fi
 
 setenv rauc_active
+setenv rauc_candidate
 for BOOT_SLOT in "${BOOT_ORDER}"; do
 if test "x${rauc_active}" != "x"; then
     # skip remaining slots
   elif test "x${BOOT_SLOT}" = "xA"; then
     if test 0x${BOOT_A_LEFT} -gt 0; then
-      echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
-      setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
       setenv mmcpart 3
-      setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_a_nandoffset} ${kernel_size}"
-      setenv rauc_slot "rauc.slot=A"
-      setenv rauc_last_booted A
-      setenv rauc_active "1"
+      setenv rauc_candidate A
     fi
   elif test "x${BOOT_SLOT}" = "xB"; then
     if test 0x${BOOT_B_LEFT} -gt 0; then
-      echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
-      setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
       setenv mmcpart 4
-      setenv rauc_slot "rauc.slot=B"
-      setenv rauc_last_booted B
-      setenv rauc_active "1"
+      setenv rauc_candidate B
     fi
+  fi
+
+  # An attempt counter above zero only means RAUC has not marked the slot bad.
+  # Factory machines ship with an empty slot B, so validate that the candidate
+  # actually holds a loadable kernel and device tree before spending an attempt
+  # on it. A slot that fails here is skipped without touching its counter, so
+  # the selector moves on to the next slot instead of booting into nothing.
+  if test -n "${rauc_candidate}"; then
+    if load mmc ${mmcdev}:${mmcpart} ${img_addr} ${bootdir}/${image}; then
+      if unzip ${img_addr} ${loadaddr}; then
+        if run loadfdt; then
+          if test "x${rauc_candidate}" = "xA"; then
+            echo "Found valid slot A, ${BOOT_A_LEFT} attempts remaining"
+            setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
+            setenv load_kernel "nand read ${kernel_loadaddr} ${kernel_a_nandoffset} ${kernel_size}"
+            setenv rauc_slot "rauc.slot=A"
+            setenv rauc_last_booted A
+          else
+            echo "Found valid slot B, ${BOOT_B_LEFT} attempts remaining"
+            setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
+            setenv rauc_slot "rauc.slot=B"
+            setenv rauc_last_booted B
+          fi
+          setenv rauc_active "1"
+        else
+          echo "Slot ${rauc_candidate} skipped: no usable device tree"
+        fi
+      else
+        echo "Slot ${rauc_candidate} skipped: kernel is corrupt"
+      fi
+    else
+      echo "Slot ${rauc_candidate} skipped: no usable kernel"
+    fi
+    setenv rauc_candidate
   fi
 done
 

--- a/tests/test_rear_button_boot_switch.py
+++ b/tests/test_rear_button_boot_switch.py
@@ -18,12 +18,6 @@ def switch_block() -> str:
     return SCRIPT[start:end]
 
 
-def selector_block() -> str:
-    start = SCRIPT.index("\nsetenv rauc_active")
-    end = SCRIPT.index("\ndone", start)
-    return SCRIPT[start:end]
-
-
 def run_boot_script(**environment):
     """Run the production Hush script with deterministic command stubs."""
     # Bash and Hush differ in quoted for-loop word splitting for this script.
@@ -448,27 +442,6 @@ printf 'bundle' > "$5"
 
 
 class AutomaticFallbackPreflightTests(unittest.TestCase):
-    def test_selector_spends_an_attempt_only_after_kernel_and_device_tree_checks(self):
-        block = selector_block()
-        load_kernel = block.index(
-            "if load mmc ${mmcdev}:${mmcpart} ${img_addr} ${bootdir}/${image}; then"
-        )
-        decompress_kernel = block.index("if unzip ${img_addr} ${loadaddr}; then")
-        load_fdt = block.index("if run loadfdt; then", decompress_kernel)
-        spend_a = block.index("setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1")
-        spend_b = block.index("setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1")
-        activate = block.index('setenv rauc_active "1"')
-
-        self.assertLess(load_kernel, decompress_kernel)
-        self.assertLess(decompress_kernel, load_fdt)
-        self.assertLess(load_fdt, spend_a)
-        self.assertLess(load_fdt, spend_b)
-        self.assertLess(spend_b, activate)
-        self.assertEqual(block.count("skipped:"), 3)
-        self.assertIn("no usable kernel", block)
-        self.assertIn("kernel is corrupt", block)
-        self.assertIn("no usable device tree", block)
-
     def test_exhausted_primary_never_falls_back_onto_an_empty_slot(self):
         # Factory-fresh machine after the repeated-restart rollback: slot A has
         # exhausted its attempts and slot B is a formatted but empty filesystem.

--- a/tests/test_rear_button_boot_switch.py
+++ b/tests/test_rear_button_boot_switch.py
@@ -18,6 +18,12 @@ def switch_block() -> str:
     return SCRIPT[start:end]
 
 
+def selector_block() -> str:
+    start = SCRIPT.index("\nsetenv rauc_active")
+    end = SCRIPT.index("\ndone", start)
+    return SCRIPT[start:end]
+
+
 def run_boot_script(**environment):
     """Run the production Hush script with deterministic command stubs."""
     # Bash and Hush differ in quoted for-loop word splitting for this script.
@@ -50,7 +56,10 @@ load() {
   fi
   return 0
 }
-unzip() { UNZIP_PARTS="${UNZIP_PARTS} ${mmcpart}"; return 0; }
+unzip() {
+  UNZIP_PARTS="${UNZIP_PARTS} ${mmcpart}"
+  [ "${mmcpart}" != "${CORRUPT_KERNEL_PART}" ]
+}
 run() {
   case "$1" in
     loadimage)
@@ -73,7 +82,7 @@ source "$1"
 script_status=$?
 [ "$script_status" -eq 0 ] || exit "$script_status"
 printf '\n__STATE__\n'
-for name in BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT rauc_last_booted rauc_switch_requested LOAD_PARTS UNZIP_PARTS SAVEENV_CALLS; do
+for name in BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT rauc_last_booted rauc_switch_requested rauc_active mmcpart LOAD_PARTS UNZIP_PARTS SAVEENV_CALLS; do
   printf '%s=%s\n' "$name" "${!name-}"
 done
 '''
@@ -85,6 +94,7 @@ done
         "bootdir": "/boot",
         "image": "Image.gz",
         "MISSING_KERNEL_PART": "none",
+        "CORRUPT_KERNEL_PART": "none",
     }
     with tempfile.NamedTemporaryFile("w", delete=False) as script_file:
         script_file.write(bash_script)
@@ -150,9 +160,10 @@ class RearButtonBootSwitchTests(unittest.TestCase):
 
         self.assertEqual(state["BOOT_ORDER"], "A B")
         self.assertEqual(state["BOOT_B_LEFT"], "3")
-        # The normal A boot decompresses once. The missing B preflight must not
-        # call unzip even though the harness models stale compressed RAM.
-        self.assertEqual(state["UNZIP_PARTS"].split(), ["3"])
+        # The normal A boot decompresses twice (selector preflight, then the
+        # authoritative loadimage). The missing B preflight must not call unzip
+        # even though the harness models stale compressed RAM.
+        self.assertEqual(state["UNZIP_PARTS"].split(), ["3", "3"])
         self.assertIn("no usable kernel", state["OUTPUT"])
 
     def test_legacy_environment_infers_live_fallback_slot(self):
@@ -179,7 +190,8 @@ class RearButtonBootSwitchTests(unittest.TestCase):
         self.assertEqual(state["BOOT_ORDER"], "B A")
         self.assertEqual(state["BOOT_B_LEFT"], "0")
         self.assertEqual(state["rauc_last_booted"], "B")
-        self.assertEqual(state["UNZIP_PARTS"].split(), ["4", "4"])
+        # Rear-button preflight, selector preflight, then loadimage.
+        self.assertEqual(state["UNZIP_PARTS"].split(), ["4", "4", "4"])
 
     def test_bootloader_ota_carries_and_orders_fail_safe_script_activation(self):
         self.assertIn('cp "$BOOT_SCRIPT_PATH" "$CONTENT_DIR/u-boot.scr"', OTA_BUILDER)
@@ -433,6 +445,117 @@ printf 'bundle' > "$5"
             bundles = list(temp.glob("rauc_meticulous_boot_sw122-test-*.raucb"))
             self.assertEqual(len(bundles), 1)
             self.assertEqual(bundles[0].read_bytes(), b"bundle")
+
+
+class AutomaticFallbackPreflightTests(unittest.TestCase):
+    def test_selector_spends_an_attempt_only_after_kernel_and_device_tree_checks(self):
+        block = selector_block()
+        load_kernel = block.index(
+            "if load mmc ${mmcdev}:${mmcpart} ${img_addr} ${bootdir}/${image}; then"
+        )
+        decompress_kernel = block.index("if unzip ${img_addr} ${loadaddr}; then")
+        load_fdt = block.index("if run loadfdt; then", decompress_kernel)
+        spend_a = block.index("setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1")
+        spend_b = block.index("setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1")
+        activate = block.index('setenv rauc_active "1"')
+
+        self.assertLess(load_kernel, decompress_kernel)
+        self.assertLess(decompress_kernel, load_fdt)
+        self.assertLess(load_fdt, spend_a)
+        self.assertLess(load_fdt, spend_b)
+        self.assertLess(spend_b, activate)
+        self.assertEqual(block.count("skipped:"), 3)
+        self.assertIn("no usable kernel", block)
+        self.assertIn("kernel is corrupt", block)
+        self.assertIn("no usable device tree", block)
+
+    def test_exhausted_primary_never_falls_back_onto_an_empty_slot(self):
+        # Factory-fresh machine after the repeated-restart rollback: slot A has
+        # exhausted its attempts and slot B is a formatted but empty filesystem.
+        state = run_boot_script(
+            BOOT_ORDER="A B",
+            BOOT_A_LEFT="0",
+            BOOT_B_LEFT="3",
+            rauc_last_booted="A",
+            MISSING_KERNEL_PART="4",
+        )
+
+        self.assertIn("Slot B skipped: no usable kernel", state["OUTPUT"])
+        self.assertIn("No valid slot found", state["OUTPUT"])
+        self.assertEqual(state["rauc_active"], "")
+        self.assertEqual(state["rauc_last_booted"], "A")
+        self.assertEqual(state["BOOT_ORDER"], "A B")
+        # Counters are reset so the next start retries the populated slot A
+        # instead of committing to a slot that cannot boot.
+        self.assertEqual(state["BOOT_A_LEFT"], "3")
+        self.assertEqual(state["BOOT_B_LEFT"], "3")
+        self.assertEqual(state["UNZIP_PARTS"].split(), [])
+
+    def test_exhausted_primary_falls_back_onto_a_validated_slot(self):
+        state = run_boot_script(
+            BOOT_ORDER="A B",
+            BOOT_A_LEFT="0",
+            BOOT_B_LEFT="3",
+            rauc_last_booted="A",
+        )
+
+        self.assertIn("Found valid slot B, 3 attempts remaining", state["OUTPUT"])
+        self.assertEqual(state["rauc_active"], "1")
+        self.assertEqual(state["rauc_last_booted"], "B")
+        self.assertEqual(state["mmcpart"], "4")
+        self.assertEqual(state["BOOT_A_LEFT"], "0")
+        self.assertEqual(state["BOOT_B_LEFT"], "2")
+        self.assertEqual(state["LOAD_PARTS"].split(), ["4", "4", "4"])
+        self.assertEqual(state["UNZIP_PARTS"].split(), ["4", "4"])
+
+    def test_missing_kernel_on_primary_skips_it_without_spending_an_attempt(self):
+        state = run_boot_script(
+            BOOT_ORDER="A B",
+            BOOT_A_LEFT="3",
+            BOOT_B_LEFT="3",
+            rauc_last_booted="B",
+            MISSING_KERNEL_PART="3",
+        )
+
+        self.assertIn("Slot A skipped: no usable kernel", state["OUTPUT"])
+        self.assertIn("Found valid slot B, 3 attempts remaining", state["OUTPUT"])
+        self.assertEqual(state["BOOT_A_LEFT"], "3")
+        self.assertEqual(state["BOOT_B_LEFT"], "2")
+        self.assertEqual(state["rauc_last_booted"], "B")
+        self.assertEqual(state["mmcpart"], "4")
+        # The failed slot A load must not be followed by a decompression.
+        self.assertEqual(state["UNZIP_PARTS"].split(), ["4", "4"])
+
+    def test_corrupt_kernel_on_primary_skips_it_without_spending_an_attempt(self):
+        state = run_boot_script(
+            BOOT_ORDER="A B",
+            BOOT_A_LEFT="3",
+            BOOT_B_LEFT="3",
+            rauc_last_booted="A",
+            CORRUPT_KERNEL_PART="3",
+        )
+
+        self.assertIn("Slot A skipped: kernel is corrupt", state["OUTPUT"])
+        self.assertEqual(state["BOOT_A_LEFT"], "3")
+        self.assertEqual(state["BOOT_B_LEFT"], "2")
+        self.assertEqual(state["rauc_last_booted"], "B")
+        self.assertEqual(state["UNZIP_PARTS"].split(), ["3", "4", "4"])
+
+    def test_healthy_primary_boot_is_unchanged_apart_from_the_preflight(self):
+        state = run_boot_script(
+            BOOT_ORDER="A B",
+            BOOT_A_LEFT="3",
+            BOOT_B_LEFT="3",
+            rauc_last_booted="A",
+        )
+
+        self.assertIn("Found valid slot A, 3 attempts remaining", state["OUTPUT"])
+        self.assertEqual(state["BOOT_A_LEFT"], "2")
+        self.assertEqual(state["BOOT_B_LEFT"], "3")
+        self.assertEqual(state["rauc_last_booted"], "A")
+        self.assertEqual(state["mmcpart"], "3")
+        self.assertEqual(state["SAVEENV_CALLS"], "1")
+        self.assertEqual(state["LOAD_PARTS"].split(), ["3", "3", "3"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The boot selector committed to a slot as soon as its attempt counter was above zero. Factory machines ship with slot B formatted but empty, so once slot A exhausted its attempts the machine switched onto B and stopped on a black screen. Run the same load, unzip and loadfdt preflight that guards the rear-button switch on every candidate slot, skip a slot that fails without spending an attempt, and let the counter reset return the machine to slot A.

Addresses [sw-bug-tracking RC-5](https://github.com/AluUriel/sw-bug-tracking/blob/5c9a1b12d45127a17ef4956607da78f74f52903f/Root%20Causes/RC-5%20Empty%20partition%20B%20rollback%20on%20factory%20machines.md)